### PR TITLE
Add C# name overrides

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
 		<OpenApiTypeScriptMswVersion>0.8.1</OpenApiTypeScriptMswVersion>
 		<OpenApiTypeScriptFetchVersion>0.8.1</OpenApiTypeScriptFetchVersion>
 		<!-- Should be incremented anytime one of the internal libraries changes -->
-		<SharedAnalyzerLibrariesVersion>0.7.0</SharedAnalyzerLibrariesVersion>
+		<SharedAnalyzerLibrariesVersion>0.8.0</SharedAnalyzerLibrariesVersion>
 	</PropertyGroup>
 
 	<Import Project="Directory.Build.local.props" Condition="exists('$(MSBuildThisFileDirectory)Directory.Build.local.props')" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,8 +30,8 @@
 
 	<PropertyGroup>
 		<OpenApiJsonExtensionsVersion>0.17.1</OpenApiJsonExtensionsVersion>
-		<OpenApiMvcServerVersion>0.17.1</OpenApiMvcServerVersion>
-		<OpenApiCSharpClientVersion>0.17.1</OpenApiCSharpClientVersion>
+		<OpenApiMvcServerVersion>0.18.0</OpenApiMvcServerVersion>
+		<OpenApiCSharpClientVersion>0.18.0</OpenApiCSharpClientVersion>
 		<OpenApiTypeScriptClientVersion>0.10.0</OpenApiTypeScriptClientVersion>
 		<OpenApiTypeScriptRxjsClientVersion>0.8.1</OpenApiTypeScriptRxjsClientVersion>
 		<OpenApiTypeScriptMswVersion>0.8.1</OpenApiTypeScriptMswVersion>

--- a/eng/source-generators/BaseGenerator.cs
+++ b/eng/source-generators/BaseGenerator.cs
@@ -127,7 +127,8 @@ public abstract class BaseGenerator :
 		// Build an incremental "watcher"
 		var allAdditionalTexts = context.AdditionalTextsProvider.Combine(context.AnalyzerConfigOptionsProvider)
 			.Select(static (tuple, cancellation) => GetOptions(tuple.Left, tuple.Right))
-			.Where(static (tuple) => tuple.TextContents != null);
+			.Where(static (tuple) => tuple.TextContents != null)
+			.Where(IsRelevantFile);
 		// TODO: the incremental watcher could include only the additional texts actually needed
 		var additionalTexts = allAdditionalTexts
 			.Where(IsEntrypointFile)
@@ -144,12 +145,13 @@ public abstract class BaseGenerator :
 		ReportCompilationDiagnostics(context.Compilation, context);
 
 		var allAdditionalTexts = context.AdditionalFiles.Select(file => GetOptions(file, context.AnalyzerConfigOptions))
-			.Where(static (tuple) => tuple.TextContents != null);
+			.Where(static (tuple) => tuple.TextContents != null)
+			.Where(IsRelevantFile);
 		var additionalTexts = allAdditionalTexts
 			.Where(IsEntrypointFile);
 		foreach (var additionalText in additionalTexts)
 		{
-			GenerateSources(additionalText, additionalTexts, context);
+			GenerateSources(additionalText, allAdditionalTexts, context);
 		}
 	}
 

--- a/eng/source-generators/BaseGenerator.cs
+++ b/eng/source-generators/BaseGenerator.cs
@@ -22,6 +22,8 @@ public abstract class BaseGenerator :
 	ISourceGenerator
 #endif
 {
+	private const string additionalTextInfoAssemblyName = "DarkPatterns.OpenApiCodegen.0.8.0";
+	private const string additionalTextInfoTypeName = "DarkPatterns.OpenApiCodegen.AdditionalTextInfo";
 	private static readonly DiagnosticDescriptor OpenApiConversionError = new DiagnosticDescriptor(id: "DPD_PARSE_UNK",
 																								title: "A conversion error was encountered",
 																								messageFormat: "A conversion error was encountered: {0}",
@@ -32,7 +34,8 @@ public abstract class BaseGenerator :
 	private static readonly object lockHandle = new object();
 
 	private readonly Func<IEnumerable<string>> getMetadataKeys;
-	private readonly Func<string, string, IReadOnlyDictionary<string, string?>, object> generate;
+	private readonly Func<string, string, IReadOnlyDictionary<string, string?>, object> toAdditionalTextType;
+	private readonly Func<object, object[], object> generate;
 
 	protected BaseGenerator(string generatorTypeName, string assemblyName)
 	{
@@ -48,19 +51,30 @@ public abstract class BaseGenerator :
 		// See https://github.com/dotnet/runtime/issues/11895, https://github.com/dotnet/runtime/issues/12668
 		var generatorType = GetEmbeddedAssemblyByName(assemblyName)?.GetType(generatorTypeName, throwOnError: false)
 			?? throw new InvalidOperationException($"Could not find generator {generatorTypeName}");
+		var additionalTextType = GetEmbeddedAssemblyByName(additionalTextInfoAssemblyName)?.GetType(additionalTextInfoTypeName, throwOnError: false)
+			?? throw new InvalidOperationException($"Could not find type {additionalTextInfoTypeName} in {additionalTextInfoAssemblyName}");
 
 		var generator = Activator.CreateInstance(generatorType);
-
-		var generateMethod = generatorType.GetMethod("Generate")!;
 		var generatorExpression = Constant(generator);
-		var compilerApisParameter = Parameter(typeof(CompilerApis));
+
+		var toAdditionalTextTypeMethod = generatorType.GetMethod("ToFileInfo")!;
 		var pathParameter = Parameter(typeof(string));
 		var textParameter = Parameter(typeof(string));
 		var dictionaryParameter = Parameter(typeof(IReadOnlyDictionary<string, string?>));
 		getMetadataKeys = Lambda<Func<IEnumerable<string>>>(Property(generatorExpression, "MetadataKeys")).Compile();
-		generate = Lambda<Func<string, string, IReadOnlyDictionary<string, string?>, object>>(
-			Convert(Call(generatorExpression, generateMethod, pathParameter, textParameter, dictionaryParameter), typeof(object))
+		toAdditionalTextType = Lambda<Func<string, string, IReadOnlyDictionary<string, string?>, object>>(
+			Convert(Call(generatorExpression, toAdditionalTextTypeMethod, pathParameter, textParameter, dictionaryParameter), typeof(object))
 			, pathParameter, textParameter, dictionaryParameter).Compile();
+
+		var generateMethod = generatorType.GetMethod("Generate")!;
+		var ofTypeMethod = typeof(Enumerable).GetMethod(nameof(Enumerable.OfType))!.MakeGenericMethod(generateMethod.GetParameters()[1].ParameterType.GetGenericArguments())!;
+		var entrypointParameter = Parameter(typeof(object));
+		var otherFilesParameter = Parameter(typeof(object[]));
+		generate = Lambda<Func<object, object[], object>>(
+			Convert(Call(generatorExpression, generateMethod,
+				Convert(entrypointParameter, generateMethod.GetParameters()[0].ParameterType),
+				Call(null, ofTypeMethod, otherFilesParameter)), typeof(object))
+			, entrypointParameter, otherFilesParameter).Compile();
 
 		Assembly? ResolveAssembly(object sender, ResolveEventArgs ev)
 		{
@@ -101,6 +115,8 @@ public abstract class BaseGenerator :
 	}
 
 #if ROSLYN4_0_OR_GREATER
+	record IncrementalData(AdditionalTextWithOptions Entrypoint, IEnumerable<AdditionalTextWithOptions> OtherKnownSchemas);
+
 	public virtual void Initialize(IncrementalGeneratorInitializationContext context)
 	{
 		context.RegisterImplementationSourceOutput(context.CompilationProvider, (context, compilation) =>
@@ -108,13 +124,18 @@ public abstract class BaseGenerator :
 			ReportCompilationDiagnostics(compilation, context);
 		});
 
-		var additionalTexts = context.AdditionalTextsProvider.Combine(context.AnalyzerConfigOptionsProvider)
-			.Select(static (tuple, _) => GetOptions(tuple.Left, tuple.Right))
-			.Where(static (tuple) => tuple.TextContents != null)
-			.Where(IsRelevantFile);
+		// Build an incremental "watcher"
+		var allAdditionalTexts = context.AdditionalTextsProvider.Combine(context.AnalyzerConfigOptionsProvider)
+			.Select(static (tuple, cancellation) => GetOptions(tuple.Left, tuple.Right))
+			.Where(static (tuple) => tuple.TextContents != null);
+		// TODO: the incremental watcher could include only the additional texts actually needed
+		var additionalTexts = allAdditionalTexts
+			.Where(IsEntrypointFile)
+			.Combine(allAdditionalTexts.Collect())
+			.Select(static (tuple, cancellation) => new IncrementalData(tuple.Left, tuple.Right.ToArray()));
 		context.RegisterSourceOutput(additionalTexts, (context, tuple) =>
 		{
-			GenerateSources(tuple, context);
+			GenerateSources(tuple.Entrypoint, tuple.OtherKnownSchemas, context);
 		});
 	}
 #else
@@ -122,12 +143,13 @@ public abstract class BaseGenerator :
 	{
 		ReportCompilationDiagnostics(context.Compilation, context);
 
-		var additionalTexts = context.AdditionalFiles.Select(file => GetOptions(file, context.AnalyzerConfigOptions))
-			.Where(static (tuple) => tuple.TextContents != null)
-			.Where(IsRelevantFile);
+		var allAdditionalTexts = context.AdditionalFiles.Select(file => GetOptions(file, context.AnalyzerConfigOptions))
+			.Where(static (tuple) => tuple.TextContents != null);
+		var additionalTexts = allAdditionalTexts
+			.Where(IsEntrypointFile);
 		foreach (var additionalText in additionalTexts)
 		{
-			GenerateSources(additionalText, context);
+			GenerateSources(additionalText, additionalTexts, context);
 		}
 	}
 
@@ -157,17 +179,15 @@ public abstract class BaseGenerator :
 	}
 
 	protected abstract void ReportCompilationDiagnostics(Compilation compilation, CompilerApis apis);
+	protected abstract bool IsEntrypointFile(AdditionalTextWithOptions additionalText);
 	protected abstract bool IsRelevantFile(AdditionalTextWithOptions additionalText);
-	private void GenerateSources(AdditionalTextWithOptions additionalText, CompilerApis apis)
+	private void GenerateSources(AdditionalTextWithOptions additionalText, IEnumerable<AdditionalTextWithOptions> otherAdditionalText, CompilerApis apis)
 	{
 		IEnumerable<string> metadataKeys = getMetadataKeys();
 		// result is of type DarkPatterns.OpenApiCodegen.GenerationResult
 		dynamic result = generate(
-			additionalText.Path,
-			additionalText.TextContents,
-			new ReadOnlyDictionary<string, string?>(
-				metadataKeys.ToDictionary(key => key, additionalText.ConfigOptions.GetAdditionalFilesMetadata)
-			)
+			ToAdditionalFileType(additionalText, metadataKeys),
+			otherAdditionalText.Select(f => ToAdditionalFileType(f, metadataKeys)).ToArray()
 		);
 		foreach (var entry in result.Sources)
 		{
@@ -206,6 +226,17 @@ public abstract class BaseGenerator :
 					)
 				);
 		}
+	}
+
+	object ToAdditionalFileType(AdditionalTextWithOptions additionalText, IEnumerable<string> metadataKeys)
+	{
+		return toAdditionalTextType(
+					additionalText.Path,
+					additionalText.TextContents,
+					new ReadOnlyDictionary<string, string?>(
+						metadataKeys.ToDictionary(key => key, additionalText.ConfigOptions.GetAdditionalFilesMetadata)
+					)
+				);
 	}
 
 

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Analyzers/OpenApiMvcServerGenerator.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Analyzers/OpenApiMvcServerGenerator.cs
@@ -20,7 +20,7 @@ namespace DarkPatterns.OpenApiCodegen.Server.Mvc
 	{
 		private const string sourceItemGroupKey = "SourceItemGroup";
 		const string sourceGroup = "OpenApiServerInterface";
-		const string sharedSourceGroup = "JsonDocumentRegistry";
+		const string sharedSourceGroup = "JsonSchemaDocument";
 		private static readonly DiagnosticDescriptor IncludeDependentDll = new DiagnosticDescriptor(id: "DPDAPICTRL001",
 																									title: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",
 																									messageFormat: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Analyzers/OpenApiMvcServerGenerator.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Analyzers/OpenApiMvcServerGenerator.cs
@@ -18,9 +18,9 @@ namespace DarkPatterns.OpenApiCodegen.Server.Mvc
 	[Generator]
 	public sealed class OpenApiMvcServerGenerator : BaseGenerator
 	{
-		const string sourceGroup = "OpenApiServerInterface";
-
 		private const string sourceItemGroupKey = "SourceItemGroup";
+		const string sourceGroup = "OpenApiServerInterface";
+		const string sharedSourceGroup = "JsonDocumentRegistry";
 		private static readonly DiagnosticDescriptor IncludeDependentDll = new DiagnosticDescriptor(id: "DPDAPICTRL001",
 																									title: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",
 																									messageFormat: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",
@@ -41,10 +41,16 @@ namespace DarkPatterns.OpenApiCodegen.Server.Mvc
 			}
 		}
 
+		protected override bool IsEntrypointFile(AdditionalTextWithOptions additionalText)
+		{
+			string? currentSourceGroup = additionalText.ConfigOptions.GetAdditionalFilesMetadata(sourceItemGroupKey);
+			return currentSourceGroup == sourceGroup;
+		}
+
 		protected override bool IsRelevantFile(AdditionalTextWithOptions additionalText)
 		{
 			string? currentSourceGroup = additionalText.ConfigOptions.GetAdditionalFilesMetadata(sourceItemGroupKey);
-			if (currentSourceGroup != sourceGroup)
+			if (currentSourceGroup != sourceGroup && currentSourceGroup != sharedSourceGroup)
 			{
 				return false;
 			}

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/CSharpControllerTransformer.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/CSharpControllerTransformer.cs
@@ -13,17 +13,15 @@ namespace DarkPatterns.OpenApi.CSharp
 		private readonly DocumentRegistry documentRegistry;
 		private readonly ISchemaRegistry schemaRegistry;
 		private readonly OpenApiDocument document;
-		private readonly string baseNamespace;
 		private readonly CSharpServerSchemaOptions options;
 		private readonly string versionInfo;
 		private readonly HandlebarsFactory handlebarsFactory;
 
-		public CSharpControllerTransformer(DocumentRegistry documentRegistry, ISchemaRegistry schemaRegistry, OpenApiDocument document, string baseNamespace, CSharpServerSchemaOptions options, string versionInfo, HandlebarsFactory handlebarsFactory)
+		public CSharpControllerTransformer(DocumentRegistry documentRegistry, ISchemaRegistry schemaRegistry, OpenApiDocument document, CSharpServerSchemaOptions options, string versionInfo, HandlebarsFactory handlebarsFactory)
 		{
 			this.documentRegistry = documentRegistry;
 			this.schemaRegistry = schemaRegistry;
 			this.document = document;
-			this.baseNamespace = baseNamespace;
 			this.options = options;
 			this.versionInfo = versionInfo;
 			this.handlebarsFactory = handlebarsFactory;
@@ -32,6 +30,7 @@ namespace DarkPatterns.OpenApi.CSharp
 		public SourceEntry TransformController(string groupName, OperationGroupData groupData, OpenApiTransformDiagnostic diagnostic)
 		{
 			var (summary, description, operations) = groupData;
+			var baseNamespace = options.DefaultNamespace;
 
 			var className = CSharpNaming.ToClassName(groupName + " base", options.ReservedIdentifiers());
 
@@ -72,6 +71,7 @@ namespace DarkPatterns.OpenApi.CSharp
 
 		internal SourceEntry TransformAddServicesHelper(IEnumerable<string> groups, OpenApiTransformDiagnostic diagnostic)
 		{
+			var baseNamespace = options.DefaultNamespace;
 			return new SourceEntry(
 				Key: $"{baseNamespace}.AddServicesExtensions.cs",
 				SourceText: handlebarsFactory.Handlebars.ProcessAddServices(new Templates.AddServicesModel(

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/CSharpSchemaServerExtensionsOptions.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/CSharpSchemaServerExtensionsOptions.cs
@@ -1,0 +1,6 @@
+namespace DarkPatterns.OpenApi.CSharp;
+
+public class CSharpSchemaServerExtensionsOptions : CSharpSchemaExtensionsOptions
+{
+	public string ControllerName { get; set; } = "dotnet-mvc-server-controller";
+}

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/CSharpServerSchemaOptions.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/CSharpServerSchemaOptions.cs
@@ -1,10 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace DarkPatterns.OpenApi.CSharp;
 
 public class CSharpServerSchemaOptions : CSharpSchemaOptions
 {
+	public CSharpServerSchemaOptions()
+	{
+		Extensions = new();
+	}
+
+	public new CSharpSchemaServerExtensionsOptions Extensions
+	{
+		get { return (base.Extensions as CSharpSchemaServerExtensionsOptions)!; }
+		set { base.Extensions = value; }
+	}
 	public string PathPrefix { get; set; } = "";
+
+
+	public static System.IO.Stream GetServerDefaultOptionsJson() =>
+		typeof(CSharpServerSchemaOptions).Assembly.GetManifestResourceStream($"{typeof(CSharpServerSchemaOptions).Namespace}.csharp.config.yaml");
 }

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/MvcServerGenerator.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/MvcServerGenerator.cs
@@ -82,8 +82,10 @@ public class MvcServerGenerator : IOpenApiCodeGenerator
 		var optionsFiles = entrypointMetadata[propConfig];
 		var pathPrefix = entrypointMetadata[propPathPrefix];
 		using var defaultJsonStream = CSharpSchemaOptions.GetDefaultOptionsJson();
+		using var serverJsonStream = CSharpServerSchemaOptions.GetServerDefaultOptionsJson();
 		var builder = new ConfigurationBuilder();
 		builder.AddYamlStream(defaultJsonStream);
+		builder.AddYamlStream(serverJsonStream);
 		if (optionsFiles is { Length: > 0 })
 		{
 			foreach (var file in optionsFiles.Split(';'))

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/MvcServerGenerator.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/MvcServerGenerator.cs
@@ -8,8 +8,6 @@ using System.Linq;
 using DarkPatterns.OpenApi.Transformations.DocumentTypes;
 using DarkPatterns.OpenApi.Transformations.Specifications;
 using DarkPatterns.OpenApi.Transformations.Diagnostics;
-using System.IO;
-using System.Net.Mime;
 
 namespace DarkPatterns.OpenApi.CSharp;
 
@@ -20,6 +18,7 @@ public class MvcServerGenerator : IOpenApiCodeGenerator
 	const string propIdentity = "identity";
 	const string propLink = "link";
 	const string propPathPrefix = "pathPrefix";
+	const string propSchemaId = "schemaId";
 	private readonly IEnumerable<string> metadataKeys = new[]
 	{
 		propNamespace,
@@ -27,6 +26,7 @@ public class MvcServerGenerator : IOpenApiCodeGenerator
 		propIdentity,
 		propLink,
 		propPathPrefix,
+		propSchemaId,
 	};
 
 	public IEnumerable<string> MetadataKeys => metadataKeys;
@@ -130,7 +130,7 @@ public class MvcServerGenerator : IOpenApiCodeGenerator
 	}
 
 	private static Uri ToInternalUri(AdditionalTextInfo document) =>
-		// TODO: check schema url from metadata
+		document.Metadata.TryGetValue(propSchemaId, out var schemaId) && schemaId is { Length: > 0 } ? new Uri(schemaId) :
 		new Uri(new Uri(document.Path).AbsoluteUri);
 
 	private static (IDocumentReference, DocumentRegistry) LoadDocument(AdditionalTextInfo document, CSharpServerSchemaOptions options, IEnumerable<AdditionalTextInfo> additionalSchemas)

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/MvcServerGenerator.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/MvcServerGenerator.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using DarkPatterns.OpenApi.Transformations.DocumentTypes;
 using DarkPatterns.OpenApi.Transformations.Specifications;
 using DarkPatterns.OpenApi.Transformations.Diagnostics;
+using System.IO;
+using System.Net.Mime;
 
 namespace DarkPatterns.OpenApi.CSharp;
 
@@ -29,16 +31,21 @@ public class MvcServerGenerator : IOpenApiCodeGenerator
 
 	public IEnumerable<string> MetadataKeys => metadataKeys;
 
-	public GenerationResult Generate(string documentPath, string documentContents, IReadOnlyDictionary<string, string?> additionalTextMetadata)
+	public AdditionalTextInfo ToFileInfo(string documentPath, string documentContents, IReadOnlyDictionary<string, string?> additionalTextMetadata)
 	{
-		var options = LoadOptionsFromMetadata(additionalTextMetadata);
-		var (baseDocument, registry) = LoadDocument(documentPath, documentContents, options);
+		return new(Path: documentPath, Contents: documentContents, Metadata: additionalTextMetadata);
+	}
+
+	public GenerationResult Generate(AdditionalTextInfo entrypoint, IEnumerable<AdditionalTextInfo> other)
+	{
+		var options = LoadOptionsFromMetadata(entrypoint.Metadata, other);
+		var (baseDocument, registry) = LoadDocument(entrypoint, options, other);
 		var parseResult = CommonParsers.DefaultParsers.Parse(baseDocument, registry);
 		var parsedDiagnostics = parseResult.Diagnostics.Select(DiagnosticsConversion.ToDiagnosticInfo).ToArray();
 		if (!parseResult.HasDocument || parseResult.Document == null)
 			return new GenerationResult(Array.Empty<OpenApiCodegen.SourceEntry>(), parsedDiagnostics);
 
-		var sourceProvider = CreateSourceProvider(parseResult.Document, registry, options, additionalTextMetadata);
+		var sourceProvider = CreateSourceProvider(parseResult.Document, registry, options, entrypoint.Metadata);
 		var openApiDiagnostic = new OpenApiTransformDiagnostic();
 
 		try
@@ -74,7 +81,7 @@ public class MvcServerGenerator : IOpenApiCodeGenerator
 		return document.BuildCSharpPathControllerSourceProvider(registry, GetVersionInfo(), documentNamespace, options);
 	}
 
-	private static CSharpServerSchemaOptions LoadOptionsFromMetadata(IReadOnlyDictionary<string, string?> additionalTextMetadata)
+	private static CSharpServerSchemaOptions LoadOptionsFromMetadata(IReadOnlyDictionary<string, string?> additionalTextMetadata, IEnumerable<AdditionalTextInfo> additionalSchemas)
 	{
 		return LoadOptions(additionalTextMetadata[propConfig], additionalTextMetadata[propPathPrefix]);
 	}
@@ -119,20 +126,24 @@ public class MvcServerGenerator : IOpenApiCodeGenerator
 		return CSharpNaming.ToNamespace(rootNamespace, projectDir, identity, link, options.ReservedIdentifiers());
 	}
 
-	private static Uri ToInternalUri(string documentPath) =>
-		new Uri(new Uri(documentPath).AbsoluteUri);
+	private static Uri ToInternalUri(AdditionalTextInfo document) =>
+		// TODO: check schema url from metadata
+		new Uri(new Uri(document.Path).AbsoluteUri);
 
-	private static (IDocumentReference, DocumentRegistry) LoadDocument(string documentPath, string documentContents, CSharpServerSchemaOptions options)
+	private static (IDocumentReference, DocumentRegistry) LoadDocument(AdditionalTextInfo document, CSharpServerSchemaOptions options, IEnumerable<AdditionalTextInfo> additionalSchemas)
 	{
 		return DocumentResolverFactory.FromInitialDocumentInMemory(
-			ToInternalUri(documentPath),
-			documentContents,
-			ToResolverOptions(options)
+			ToInternalUri(document),
+			document.Contents,
+			ToResolverOptions(options, additionalSchemas)
 		);
 	}
 
-	private static DocumentRegistryOptions ToResolverOptions(CSharpServerSchemaOptions options) =>
-		new DocumentRegistryOptions([
+	private static DocumentRegistryOptions ToResolverOptions(CSharpServerSchemaOptions options, IEnumerable<AdditionalTextInfo> additionalSchemas) =>
+		new DocumentRegistryOptions(
+			additionalSchemas
+				.Select(doc => DocumentResolverFactory.LoadAs(ToInternalUri(doc), doc.Contents))
+				.ToArray()
 		// TODO: use the `options` to determine how to resolve additional documents
-		]);
+		);
 }

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/MvcServerGenerator.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/MvcServerGenerator.cs
@@ -149,6 +149,5 @@ public class MvcServerGenerator : IOpenApiCodeGenerator
 			additionalSchemas
 				.Select(doc => DocumentResolverFactory.LoadAs(ToInternalUri(doc), doc.Contents))
 				.ToArray()
-		// TODO: use the `options` to determine how to resolve additional documents
 		);
 }

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/OpenApiCodegen.Server.Mvc.Base.csproj
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/OpenApiCodegen.Server.Mvc.Base.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<RootNamespace>$(RootNamespacePrefix).OpenApi.CSharp</RootNamespace>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<VersionPrefix>$(SharedAnalyzerLibrariesVersion)</VersionPrefix>
+		<VersionPrefix>$(OpenApiMvcServerVersion)</VersionPrefix>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/OpenApiCodegen.Server.Mvc.Base.csproj
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/OpenApiCodegen.Server.Mvc.Base.csproj
@@ -11,6 +11,8 @@
 	<ItemGroup>
 		<None Remove="Templates\*.handlebars" />
 		<EmbeddedResource Include="Templates\*.handlebars" />
+		<None Remove="csharp.config.yaml" />
+		<EmbeddedResource Include="csharp.config.yaml" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/PathControllerTransformerFactory.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/PathControllerTransformerFactory.cs
@@ -6,7 +6,7 @@ namespace DarkPatterns.OpenApi.CSharp
 {
 	public static class PathControllerTransformerFactory
 	{
-		public static ISourceProvider BuildCSharpPathControllerSourceProvider(this OpenApiDocument document, DocumentRegistry documentRegistry, string versionInfo, string? documentNamespace, CSharpServerSchemaOptions options)
+		public static ISourceProvider BuildCSharpPathControllerSourceProvider(this OpenApiDocument document, DocumentRegistry documentRegistry, string versionInfo, CSharpServerSchemaOptions options)
 		{
 			ISourceProvider? result;
 			var handlebarsFactory = new HandlebarsFactory(ControllerHandlebarsTemplateProcess.CreateHandlebars);
@@ -18,8 +18,8 @@ namespace DarkPatterns.OpenApi.CSharp
 				InfoEmail: document.Info.Contact?.Email,
 				CodeGeneratorVersionInfo: versionInfo
 			);
-			var schemaProvider = new CSharpSchemaSourceProvider(documentRegistry, schemaRegistry, documentNamespace ?? "", options, handlebarsFactory, header);
-			var controllerTransformer = new CSharpControllerTransformer(documentRegistry, schemaRegistry, document, documentNamespace ?? "", options, versionInfo, handlebarsFactory);
+			var schemaProvider = new CSharpSchemaSourceProvider(documentRegistry, schemaRegistry, options, handlebarsFactory, header);
+			var controllerTransformer = new CSharpControllerTransformer(documentRegistry, schemaRegistry, document, options, versionInfo, handlebarsFactory);
 
 			var operationGrouping =
 				new PathControllerSourceTransformer(documentRegistry, schemaRegistry, document, controllerTransformer, (operation, path) =>

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/PathControllerTransformerFactory.cs
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/PathControllerTransformerFactory.cs
@@ -24,7 +24,7 @@ namespace DarkPatterns.OpenApi.CSharp
 			var operationGrouping =
 				new PathControllerSourceTransformer(documentRegistry, schemaRegistry, document, controllerTransformer, (operation, path) =>
 				{
-					var key = $"x-{options.ControllerNameExtension}";
+					var key = $"x-{options.Extensions.ControllerName}";
 					return operation.Extensions.TryGetValue(key, out var opOverride) ? opOverride?.GetValue<string>()
 						: path.Extensions.TryGetValue(key, out var pathOverride) ? pathOverride?.GetValue<string>()
 						: null;

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/csharp.config.yaml
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc.Base/csharp.config.yaml
@@ -1,0 +1,2 @@
+﻿extensions:
+  controllerName: dotnet-mvc-server-controller

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/ControllerGenerator.props
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/ControllerGenerator.props
@@ -14,6 +14,7 @@
 		<AvailableItemName Include="OpenApiSchemaCSharpServerOptions" DisplayName="C# Options for Open API Code Generation (OpenApiCodeGen)" />
 		<AvailableItemName Include="OpenApiSchemaMvcServer" DisplayName="Open API Schema MVC Server (OpenApiCodeGen)" />
 		<Watch Include="@(OpenApiSchemaMvcServer)" Condition=" '@(OpenApiSchemaMvcServer)' != '' " />
+		<Watch Include="@(JsonSchemaDocument)" Condition=" '@(OpenApiSchemaMvcServer)' != '' " />
 	</ItemGroup>
 
 	<Target Name="_InjectAdditionalFilesForOpenApiSchemaMvcServer" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
@@ -21,13 +22,13 @@
 			<AdditionalFiles Include="@(OpenApiSchemaMvcServer)">
 				<SourceItemGroup>OpenApiServerInterface</SourceItemGroup>
 			</AdditionalFiles>
-			<AdditionalFiles Include="@(JsonDocumentRegistry)">
-				<SourceItemGroup>JsonDocumentRegistry</SourceItemGroup>
+			<AdditionalFiles Include="@(JsonSchemaDocument)">
+				<SourceItemGroup>JsonSchemaDocument</SourceItemGroup>
 			</AdditionalFiles>
-			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonDocumentRegistry' ">
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonSchemaDocument' ">
 				<WorkingOutputPath Condition=" '%(AdditionalFiles.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(AdditionalFiles.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
 			</AdditionalFiles>
-			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonDocumentRegistry' ">
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonSchemaDocument' ">
 				<WorkingOutputPath Condition=" '%(AdditionalFiles.WorkingOutputPath)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(AdditionalFiles.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
 				<Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
 				<Configuration Condition=" '%(AdditionalFiles.Configuration)' == '' ">@(OpenApiSchemaCSharpServerOptions->'%(FullPath)')</Configuration>

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/ControllerGenerator.props
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/ControllerGenerator.props
@@ -10,6 +10,7 @@
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Configuration" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Namespace" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="PathPrefix" />
+		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SchemaId" />
 
 		<AvailableItemName Include="OpenApiSchemaCSharpServerOptions" DisplayName="C# Options for Open API Code Generation (OpenApiCodeGen)" />
 		<AvailableItemName Include="OpenApiSchemaMvcServer" DisplayName="Open API Schema MVC Server (OpenApiCodeGen)" />

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/ControllerGenerator.props
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/ControllerGenerator.props
@@ -18,17 +18,18 @@
 
 	<Target Name="_InjectAdditionalFilesForOpenApiSchemaMvcServer" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
 		<ItemGroup>
-			<OpenApiSchemaMvcServer>
-				<WorkingOutputPath Condition=" '%(OpenApiSchemaMvcServer.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
-			</OpenApiSchemaMvcServer>
 			<AdditionalFiles Include="@(OpenApiSchemaMvcServer)">
 				<SourceItemGroup>OpenApiServerInterface</SourceItemGroup>
 			</AdditionalFiles>
-			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' ">
+			<AdditionalFiles Include="@(JsonDocumentRegistry)">
+				<SourceItemGroup>JsonDocumentRegistry</SourceItemGroup>
+			</AdditionalFiles>
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonDocumentRegistry' ">
+				<WorkingOutputPath Condition=" '%(AdditionalFiles.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(AdditionalFiles.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+			</AdditionalFiles>
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonDocumentRegistry' ">
 				<WorkingOutputPath Condition=" '%(AdditionalFiles.WorkingOutputPath)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(AdditionalFiles.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
 				<Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
-			</AdditionalFiles>
-			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' ">
 				<Configuration Condition=" '%(AdditionalFiles.Configuration)' == '' ">@(OpenApiSchemaCSharpServerOptions->'%(FullPath)')</Configuration>
 			</AdditionalFiles>
 		</ItemGroup>

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/ControllerGenerator.props
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/ControllerGenerator.props
@@ -18,16 +18,18 @@
 
 	<Target Name="_InjectAdditionalFilesForOpenApiSchemaMvcServer" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
 		<ItemGroup>
+			<OpenApiSchemaMvcServer>
+				<WorkingOutputPath Condition=" '%(OpenApiSchemaMvcServer.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+			</OpenApiSchemaMvcServer>
 			<AdditionalFiles Include="@(OpenApiSchemaMvcServer)">
 				<SourceItemGroup>OpenApiServerInterface</SourceItemGroup>
-				<WorkingOutputPath Condition=" '%(OpenApiSchemaMvcServer.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
-				<WorkingOutputPath Condition=" '%(OpenApiSchemaMvcServer.Link)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
-				<Namespace Condition=" '%(OpenApiSchemaMvcServer.Namespace)' != '' ">%(OpenApiSchemaMvcServer.Namespace)</Namespace>
-				<Configuration Condition=" '%(OpenApiSchemaMvcServer.Configuration)' != '' ">%(OpenApiSchemaMvcServer.Configuration)</Configuration>
-				<Configuration Condition=" '%(OpenApiSchemaMvcServer.Configuration)' == '' ">@(OpenApiSchemaCSharpServerOptions->'%(FullPath)')</Configuration>
 			</AdditionalFiles>
-			<AdditionalFiles>
-				<Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' and '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' ">
+				<WorkingOutputPath Condition=" '%(AdditionalFiles.WorkingOutputPath)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(AdditionalFiles.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+				<Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
+			</AdditionalFiles>
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiServerInterface' ">
+				<Configuration Condition=" '%(AdditionalFiles.Configuration)' == '' ">@(OpenApiSchemaCSharpServerOptions->'%(FullPath)')</Configuration>
 			</AdditionalFiles>
 		</ItemGroup>
 	</Target>

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
@@ -71,6 +71,8 @@ the defaults. For example:
 ```yaml
 extensions:
   controllerName: dotnet-mvc-server-controller
+  typeNameOverride: dotnet-type-name
+  namespaceOverride: dotnet-type-namespace
 mapType: global::System.Collections.Generic.Dictionary<string, {}>
 arrayType: global::System.Collections.Generic.IEnumerable<{}>
 types:
@@ -86,6 +88,13 @@ overrideNames:
 - `extensions.controllerName` specifies the extension (for example,
   `x-dotnet-mvc-server-controller`) used to override the generated controller
   name. This may be specified on either the operation or the path level.
+- `extensions.typeNameOverride` specifies the extension (for example,
+  `x-dotnet-type-name`) used to override the generated type name. This may be
+  specified on any JSON schema that will be emitted as its own class, enum, etc.
+- `extensions.namespaceOverride` specifies the extension (for example,
+  `x-dotnet-type-namespace`) used to override the generated type namespace. This
+  may be specified on any JSON schema that will be emitted as its own class,
+  enum, etc.
 - `mapType` specifies the type to use for JSON maps, which occur when when
   `additionalProperties` is specified. `{}` is used as a placeholder for the
   type.
@@ -105,3 +114,19 @@ overrideNames:
     ```
 - `overrideNames` is a dictionary of schema URIs to the namespace-qualified C#
   type name to use for the generated class. (Note: this feature is still experimental and may change or be removed in a later relaese.)
+
+### Schema extensions
+
+Extensions in OpenAPI documents are additional properties, starting with `x-`
+that can go nearly anywhere in an OpenAPI 3.0 document. The following extensions
+are available:
+
+- `x-dotnet-mvc-server-controller` overrides the name of the controller class
+  generated for paths and operations. This extension may be specified either at
+  the path or operation level.
+- `x-dotnet-type-namespace` overrides the namespace for a single schema. This is
+  a higher-priority than settings within the csproj but lower priority than
+  individual schema name overrides in the options file.
+- `x-dotnet-type-name` overrides the type name for a single schema. This is
+  a higher-priority than settings within the csproj but lower priority than
+  individual schema name overrides in the options file.

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
@@ -16,6 +16,11 @@ You can also directly add a reference within the `.csproj` file as follows:
 
 This integrates during the build phase, so you can be sure your classes are up to date with your schema documentation.
 
+
+Additional yaml files referenced via `$ref` in your OpenAPI documents should be
+specified as the build action `JsonSchemaDocument` to be included in watch mode
+and to control the Namespace.
+
 Requirements:
 
 - System.Text.Json

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
@@ -69,7 +69,8 @@ commonly, only one or two parameters are needed. Missing keys are merged with
 the defaults. For example:
 
 ```yaml
-controllerNameExtension: dotnet-mvc-server-controller
+extensions:
+  controllerName: dotnet-mvc-server-controller
 mapType: global::System.Collections.Generic.Dictionary<string, {}>
 arrayType: global::System.Collections.Generic.IEnumerable<{}>
 types:
@@ -82,7 +83,7 @@ overrideNames:
   proj://darkpatterns-openapi/multi-file-ref-types.yaml#/BadRequest: My.Common.BadRequest
 ```
 
-- `controllerNameExtension` specifies the extension (for example,
+- `extensions.controllerName` specifies the extension (for example,
   `x-dotnet-mvc-server-controller`) used to override the generated controller
   name. This may be specified on either the operation or the path level.
 - `mapType` specifies the type to use for JSON maps, which occur when when

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
@@ -78,6 +78,8 @@ types:
       float: float
       double: double
     default: double
+overrideNames:
+  proj://darkpatterns-openapi/multi-file-ref-types.yaml#/BadRequest: My.Common.BadRequest
 ```
 
 - `controllerNameExtension` specifies the extension (for example,
@@ -100,3 +102,5 @@ types:
     type: number
     format: float
     ```
+- `overrideNames` is a dictionary of schema URIs to the namespace-qualified C#
+  type name to use for the generated class. (Note: this feature is still experimental and may change or be removed in a later relaese.)

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
@@ -49,6 +49,9 @@ Additional settings may be added within the `.csproj`. For example:
   path of the schema file
 - `Configuration` - Additional configuration settings specific to this schema.
   See the configuration yaml documentation below.
+- `PathPrefix` - Prefixes the paths of the generated paths with the given path.
+- `SchemaId` - Specifies the "retrieval URI" used when resolving relative paths
+  to external files. Otherwise, the absolute file-scheme URL will be used.
 
 In addition, adding the following to an ItemGroup in the csproj (or adding the
 yaml file with the build action `OpenApiSchemaCSharpServerOptions` via Visual

--- a/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
+++ b/generators/dotnetcore-server-interfaces/OpenApiCodegen.Server.Mvc/README.md
@@ -16,12 +16,11 @@ You can also directly add a reference within the `.csproj` file as follows:
 
 This integrates during the build phase, so you can be sure your classes are up to date with your schema documentation.
 
-
 Additional yaml files referenced via `$ref` in your OpenAPI documents should be
 specified as the build action `JsonSchemaDocument` to be included in watch mode
 and to control the Namespace.
 
-Requirements:
+## Requirements
 
 - System.Text.Json
 - C# 11+

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client.Analyzers/OpenApiCSharpClientGenerator.cs
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client.Analyzers/OpenApiCSharpClientGenerator.cs
@@ -19,6 +19,7 @@ namespace DarkPatterns.OpenApiCodegen.Client
 	{
 		private const string sourceItemGroupKey = "SourceItemGroup";
 		const string sourceGroup = "OpenApiClientInterface";
+		const string sharedSourceGroup = "JsonDocumentRegistry";
 		private static readonly DiagnosticDescriptor IncludeDependentDll = new DiagnosticDescriptor(id: "DPDAPICLNT001",
 																								  title: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",
 																								  messageFormat: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",
@@ -39,10 +40,16 @@ namespace DarkPatterns.OpenApiCodegen.Client
 			}
 		}
 
+		protected override bool IsEntrypointFile(AdditionalTextWithOptions additionalText)
+		{
+			string? currentSourceGroup = additionalText.ConfigOptions.GetAdditionalFilesMetadata(sourceItemGroupKey);
+			return currentSourceGroup == sourceGroup;
+		}
+
 		protected override bool IsRelevantFile(AdditionalTextWithOptions additionalText)
 		{
 			string? currentSourceGroup = additionalText.ConfigOptions.GetAdditionalFilesMetadata(sourceItemGroupKey);
-			if (currentSourceGroup != sourceGroup)
+			if (currentSourceGroup != sourceGroup && currentSourceGroup != sharedSourceGroup)
 			{
 				return false;
 			}

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client.Analyzers/OpenApiCSharpClientGenerator.cs
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client.Analyzers/OpenApiCSharpClientGenerator.cs
@@ -19,7 +19,7 @@ namespace DarkPatterns.OpenApiCodegen.Client
 	{
 		private const string sourceItemGroupKey = "SourceItemGroup";
 		const string sourceGroup = "OpenApiClientInterface";
-		const string sharedSourceGroup = "JsonDocumentRegistry";
+		const string sharedSourceGroup = "JsonSchemaDocument";
 		private static readonly DiagnosticDescriptor IncludeDependentDll = new DiagnosticDescriptor(id: "DPDAPICLNT001",
 																								  title: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",
 																								  messageFormat: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/CSharpClientTransformer.cs
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/CSharpClientTransformer.cs
@@ -14,17 +14,15 @@ public class CSharpClientTransformer : ISourceProvider
 	private readonly ISchemaRegistry schemaRegistry;
 	private readonly DocumentRegistry documentRegistry;
 	private readonly OpenApiDocument document;
-	private readonly string baseNamespace;
 	private readonly CSharpSchemaOptions options;
 	private readonly HandlebarsFactory handlebarsFactory;
 	private readonly PartialHeader header;
 
-	public CSharpClientTransformer(ISchemaRegistry schemaRegistry, DocumentRegistry documentRegistry, OpenApiDocument document, string baseNamespace, CSharpSchemaOptions options, HandlebarsFactory handlebarsFactory, Templates.PartialHeader header)
+	public CSharpClientTransformer(ISchemaRegistry schemaRegistry, DocumentRegistry documentRegistry, OpenApiDocument document, CSharpSchemaOptions options, HandlebarsFactory handlebarsFactory, Templates.PartialHeader header)
 	{
 		this.documentRegistry = documentRegistry;
 		this.schemaRegistry = schemaRegistry;
 		this.document = document;
-		this.baseNamespace = baseNamespace;
 		this.options = options;
 		this.handlebarsFactory = handlebarsFactory;
 		this.header = header;
@@ -34,6 +32,7 @@ public class CSharpClientTransformer : ISourceProvider
 	{
 		foreach (var schema in document.GetNestedNodes(recursive: true).OfType<JsonSchema>())
 			schemaRegistry.EnsureSchemasRegistered(schema);
+		var baseNamespace = options.DefaultNamespace;
 
 		var className = CSharpNaming.ToClassName("operations", options.ReservedIdentifiers());
 
@@ -67,6 +66,7 @@ public class CSharpClientTransformer : ISourceProvider
 
 	internal SourceEntry TransformAddServicesHelper(OpenApiTransformDiagnostic diagnostic)
 	{
+		var baseNamespace = options.DefaultNamespace;
 		return new SourceEntry(
 			Key: $"{baseNamespace}.AddServicesExtensions.cs",
 			SourceText: handlebarsFactory.Handlebars.ProcessAddServices(new Templates.AddServicesModel(

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/ClientGenerator.cs
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/ClientGenerator.cs
@@ -136,6 +136,5 @@ public class ClientGenerator : IOpenApiCodeGenerator
 			additionalSchemas
 				.Select(doc => DocumentResolverFactory.LoadAs(ToInternalUri(doc), doc.Contents))
 				.ToArray()
-		// TODO: use the `options` to determine how to resolve additional documents
 		);
 }

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/ClientGenerator.cs
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/ClientGenerator.cs
@@ -98,8 +98,8 @@ public class ClientGenerator : IOpenApiCodeGenerator
 		foreach (var entry in additionalSchemas)
 		{
 			var ns = GetStandardNamespace(entry.Metadata, result);
-			// if (result.DefaultNamespace != ns)
-			// 	result.NamespacesBySchema[ToInternalUri(entry)] = ns;
+			if (result.DefaultNamespace != ns)
+				result.NamespacesBySchema[ToInternalUri(entry)] = ns;
 		}
 		return result;
 	}

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/ClientGenerator.cs
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/ClientGenerator.cs
@@ -3,8 +3,6 @@ using DarkPatterns.OpenApi.Transformations;
 using DarkPatterns.OpenApiCodegen;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
 using System.Linq;
 using DarkPatterns.OpenApi.Transformations.DocumentTypes;
 using DarkPatterns.OpenApi.Transformations.Specifications;
@@ -18,6 +16,7 @@ public class ClientGenerator : IOpenApiCodeGenerator
 	const string propConfig = "Configuration";
 	const string propIdentity = "identity";
 	const string propLink = "link";
+	const string propSchemaId = "schemaId";
 	private readonly IEnumerable<string> metadataKeys = new[]
 	{
 		propNamespace,
@@ -120,6 +119,7 @@ public class ClientGenerator : IOpenApiCodeGenerator
 	}
 
 	private static Uri ToInternalUri(AdditionalTextInfo document) =>
+		document.Metadata.TryGetValue(propSchemaId, out var schemaId) ? new Uri(schemaId) :
 		new Uri(new Uri(document.Path).AbsoluteUri);
 
 	private static (IDocumentReference, DocumentRegistry) LoadDocument(AdditionalTextInfo document, CSharpSchemaOptions options, IEnumerable<AdditionalTextInfo> additionalSchemas)

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/ClientTransformerFactory.cs
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/ClientTransformerFactory.cs
@@ -6,7 +6,7 @@ namespace DarkPatterns.OpenApi.CSharp
 {
 	public static class ClientTransformerFactory
 	{
-		public static ISourceProvider BuildCSharpClientSourceProvider(this OpenApiDocument document, DocumentRegistry documentRegistry, string versionInfo, string? documentNamespace, CSharpSchemaOptions options)
+		public static ISourceProvider BuildCSharpClientSourceProvider(this OpenApiDocument document, DocumentRegistry documentRegistry, string versionInfo, CSharpSchemaOptions options)
 		{
 			ISourceProvider? result;
 			var handlebarsFactory = new HandlebarsFactory(ControllerHandlebarsTemplateProcess.CreateHandlebars);
@@ -19,8 +19,8 @@ namespace DarkPatterns.OpenApi.CSharp
 				CodeGeneratorVersionInfo: versionInfo
 			);
 
-			var controllerTransformer = new CSharpClientTransformer(schemaRegistry, documentRegistry, document, documentNamespace ?? "", options, handlebarsFactory, header);
-			var schemaSourceProvider = new CSharpSchemaSourceProvider(documentRegistry, schemaRegistry, documentNamespace ?? "", options, handlebarsFactory, header);
+			var controllerTransformer = new CSharpClientTransformer(schemaRegistry, documentRegistry, document, options, handlebarsFactory, header);
+			var schemaSourceProvider = new CSharpSchemaSourceProvider(documentRegistry, schemaRegistry, options, handlebarsFactory, header);
 
 			result = new CompositeOpenApiSourceProvider(
 				controllerTransformer,

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/OpenApiCodegen.Client.Base.csproj
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client.Base/OpenApiCodegen.Client.Base.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<RootNamespace>$(RootNamespacePrefix).OpenApi.CSharp</RootNamespace>
 		<TargetFramework>netstandard2.0</TargetFramework>
-		<VersionPrefix>$(SharedAnalyzerLibrariesVersion)</VersionPrefix>
+		<VersionPrefix>$(OpenApiCSharpClientVersion)</VersionPrefix>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client/ClientGenerator.props
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client/ClientGenerator.props
@@ -9,6 +9,7 @@
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SourceItemGroup" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Configuration" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Namespace" />
+		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SchemaId" />
 
 		<AvailableItemName Include="OpenApiSchemaCSharpClientOptions" DisplayName="C# Options for Open API Code Generation (OpenApiCodeGen)" />
 		<AvailableItemName Include="OpenApiSchemaClient" DisplayName="Open API Schema Client (OpenApiCodeGen)" />

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client/ClientGenerator.props
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client/ClientGenerator.props
@@ -12,7 +12,9 @@
 
 		<AvailableItemName Include="OpenApiSchemaCSharpClientOptions" DisplayName="C# Options for Open API Code Generation (OpenApiCodeGen)" />
 		<AvailableItemName Include="OpenApiSchemaClient" DisplayName="Open API Schema Client (OpenApiCodeGen)" />
+		<AvailableItemName Include="JsonSchemaDocument" DisplayName="Additional JSON Document used with JSON schemas" />
 		<Watch Include="@(OpenApiSchemaClient);@(OpenApiSchemaCSharpOptions)" Condition=" '@(OpenApiSchemaClient)' != '' " />
+		<Watch Include="@(JsonSchemaDocument)" Condition=" '@(OpenApiSchemaMvcServer)' != '' " />
 	</ItemGroup>
 
 	<Target Name="_InjectAdditionalFilesForOpenApiSchemaClient" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
@@ -20,13 +22,13 @@
 			<AdditionalFiles Include="@(OpenApiSchemaClient)">
 				<SourceItemGroup>OpenApiClientInterface</SourceItemGroup>
 			</AdditionalFiles>
-			<AdditionalFiles Include="@(JsonDocumentRegistry)">
-				<SourceItemGroup>JsonDocumentRegistry</SourceItemGroup>
+			<AdditionalFiles Include="@(JsonSchemaDocument)">
+				<SourceItemGroup>JsonSchemaDocument</SourceItemGroup>
 			</AdditionalFiles>
-			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonDocumentRegistry' ">
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonSchemaDocument' ">
 				<WorkingOutputPath Condition=" '%(AdditionalFiles.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
 			</AdditionalFiles>
-			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonDocumentRegistry' ">
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonSchemaDocument' ">
 				<WorkingOutputPath Condition=" '%(AdditionalFiles.WorkingOutputPath)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(AdditionalFiles.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
 				<Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
 			</AdditionalFiles>

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client/ClientGenerator.props
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client/ClientGenerator.props
@@ -17,16 +17,18 @@
 
 	<Target Name="_InjectAdditionalFilesForOpenApiSchemaClient" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
 		<ItemGroup>
+			<OpenApiSchemaClient>
+				<WorkingOutputPath Condition=" '%(OpenApiSchemaClient.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaClient.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+			</OpenApiSchemaClient>
 			<AdditionalFiles Include="@(OpenApiSchemaClient)">
 				<SourceItemGroup>OpenApiClientInterface</SourceItemGroup>
-				<WorkingOutputPath Condition=" '%(OpenApiSchemaClient.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaClient.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
-				<WorkingOutputPath Condition=" '%(OpenApiSchemaClient.Link)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaClient.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
-				<Namespace Condition=" '%(OpenApiSchemaClient.Namespace)' != '' ">%(OpenApiSchemaClient.Namespace)</Namespace>
-				<Configuration Condition=" '%(OpenApiSchemaClient.Configuration)' != '' ">%(OpenApiSchemaClient.Configuration)</Configuration>
-				<Configuration Condition=" '%(OpenApiSchemaClient.Configuration)' == '' ">@(OpenApiSchemaCSharpClientOptions->'%(FullPath)')</Configuration>
 			</AdditionalFiles>
-			<AdditionalFiles>
-				<Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' and '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' ">
+				<WorkingOutputPath Condition=" '%(AdditionalFiles.WorkingOutputPath)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(AdditionalFiles.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+				<Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
+			</AdditionalFiles>
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' ">
+				<Configuration Condition=" '%(AdditionalFiles.Configuration)' == '' ">@(OpenApiSchemaCSharpClientOptions->'%(FullPath)')</Configuration>
 			</AdditionalFiles>
 		</ItemGroup>
 	</Target>

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client/ClientGenerator.props
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client/ClientGenerator.props
@@ -17,13 +17,16 @@
 
 	<Target Name="_InjectAdditionalFilesForOpenApiSchemaClient" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
 		<ItemGroup>
-			<OpenApiSchemaClient>
-				<WorkingOutputPath Condition=" '%(OpenApiSchemaClient.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaClient.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
-			</OpenApiSchemaClient>
 			<AdditionalFiles Include="@(OpenApiSchemaClient)">
 				<SourceItemGroup>OpenApiClientInterface</SourceItemGroup>
 			</AdditionalFiles>
-			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' ">
+			<AdditionalFiles Include="@(JsonDocumentRegistry)">
+				<SourceItemGroup>JsonDocumentRegistry</SourceItemGroup>
+			</AdditionalFiles>
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonDocumentRegistry' ">
+				<WorkingOutputPath Condition=" '%(AdditionalFiles.Link)' != '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(OpenApiSchemaMvcServer.Link), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
+			</AdditionalFiles>
+			<AdditionalFiles Condition=" '%(AdditionalFiles.SourceItemGroup)' == 'OpenApiClientInterface' or '%(AdditionalFiles.SourceItemGroup)' == 'JsonDocumentRegistry' ">
 				<WorkingOutputPath Condition=" '%(AdditionalFiles.WorkingOutputPath)' == '' ">$([System.Text.RegularExpressions.Regex]::Replace(%(AdditionalFiles.Identity), '(?&lt;=^|\\|/)..(?=$|\\|/)', '__'))</WorkingOutputPath>
 				<Namespace Condition=" '%(AdditionalFiles.Namespace)' == '' ">$(RootNamespace)$([System.Text.RegularExpressions.Regex]::Replace($([System.Text.RegularExpressions.Regex]::Replace('/$([System.IO.Path]::GetDirectoryName('%(AdditionalFiles.WorkingOutputPath)'))', '[/\\]', '.')), '\.$', ''))</Namespace>
 			</AdditionalFiles>

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client/README.md
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client/README.md
@@ -18,6 +18,10 @@ You can also directly add a reference within the `.csproj` file as follows:
 This integrates during the build phase, so you can be sure your classes are up
 to date with your schema documentation.
 
+Additional yaml files referenced via `$ref` in your OpenAPI documents should be
+specified as the build action `JsonSchemaDocument` to be included in watch mode
+and to control the Namespace.
+
 ## Requirements
 
 - C# 11+

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client/README.md
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client/README.md
@@ -69,6 +69,9 @@ commonly, only one or two parameters are needed. Missing keys are merged with
 the defaults. For example:
 
 ```yaml
+extensions:
+  typeNameOverride: dotnet-type-name
+  namespaceOverride: dotnet-type-namespace
 mapType: global::System.Collections.Generic.Dictionary<string, {}>
 arrayType: global::System.Collections.Generic.IEnumerable<{}>
 types:
@@ -81,6 +84,14 @@ overrideNames:
   proj://darkpatterns-openapi/multi-file-ref-types.yaml#/BadRequest: My.Common.BadRequest
 ```
 
+
+- `extensions.typeNameOverride` specifies the extension (for example,
+  `x-dotnet-type-name`) used to override the generated type name. This may be
+  specified on any JSON schema that will be emitted as its own class, enum, etc.
+- `extensions.namespaceOverride` specifies the extension (for example,
+  `x-dotnet-type-namespace`) used to override the generated type namespace. This
+  may be specified on any JSON schema that will be emitted as its own class,
+  enum, etc.
 - `mapType` - Specifies the type to use for JSON maps, which occur when when
   `additionalProperties` is specified. `{}` is used as a placeholder for the
   type.
@@ -100,3 +111,16 @@ overrideNames:
     ```
 - `overrideNames` is a dictionary of schema URIs to the namespace-qualified C#
   type name to use for the generated class. (Note: this feature is still experimental and may change or be removed in a later relaese.)
+
+### Schema extensions
+
+Extensions in OpenAPI documents are additional properties, starting with `x-`
+that can go nearly anywhere in an OpenAPI 3.0 document. The following extensions
+are available:
+
+- `x-dotnet-type-namespace` overrides the namespace for a single schema. This is
+  a higher-priority than settings within the csproj but lower priority than
+  individual schema name overrides in the options file.
+- `x-dotnet-type-name` overrides the type name for a single schema. This is
+  a higher-priority than settings within the csproj but lower priority than
+  individual schema name overrides in the options file.

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client/README.md
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client/README.md
@@ -77,6 +77,8 @@ types:
       float: float
       double: double
     default: double
+overrideNames:
+  proj://darkpatterns-openapi/multi-file-ref-types.yaml#/BadRequest: My.Common.BadRequest
 ```
 
 - `mapType` - Specifies the type to use for JSON maps, which occur when when
@@ -96,3 +98,5 @@ types:
     type: number
     format: float
     ```
+- `overrideNames` is a dictionary of schema URIs to the namespace-qualified C#
+  type name to use for the generated class. (Note: this feature is still experimental and may change or be removed in a later relaese.)

--- a/generators/dotnetstandard-client/OpenApiCodegen.Client/README.md
+++ b/generators/dotnetstandard-client/OpenApiCodegen.Client/README.md
@@ -1,4 +1,4 @@
-﻿Adds source generators to generate C# client extension methods from an OpenAPI
+Adds source generators to generate C# client extension methods from an OpenAPI
 specification file.
 
 Add this package, select the OpenAPI specification file from your project, and
@@ -50,6 +50,8 @@ Additional settings may be added within the `.csproj`. For example:
   path of the schema file
 - `Configuration` - Additional configuration settings specific to this schema.
   See the configuration yaml documentation below.
+- `SchemaId` - Specifies the "retrieval URI" used when resolving relative paths
+  to external files. Otherwise, the absolute file-scheme URL will be used.
 
 In addition, adding the following to an ItemGroup in the csproj (or adding the
 yaml file with the build action `OpenApiSchemaCSharpClientOptions` via Visual

--- a/generators/typescript-rxjs/npm/vite.config.mts
+++ b/generators/typescript-rxjs/npm/vite.config.mts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [tsconfigPaths({ projects: ['./tsconfig.node.json'] })],
+	plugins: [tsconfigPaths()],
 	test: {
 		watch: false,
 	},

--- a/lib/OpenApi.CSharp/CSharpInlineSchemas.cs
+++ b/lib/OpenApi.CSharp/CSharpInlineSchemas.cs
@@ -75,7 +75,7 @@ public class CSharpInlineSchemas(CSharpSchemaOptions options, DocumentRegistry d
 
 	private string GetClassName(JsonSchema schema)
 	{
-		return CSharpNaming.ToClassName(UriToClassIdentifier(schema.Metadata.Id), options.ReservedIdentifiers());
+		return options.ToClassName(schema.Metadata.Id, UriToClassIdentifier(schema.Metadata.Id));
 	}
 
 	private static readonly Regex HttpSuccessRegex = new Regex("2[0-9]{2}");

--- a/lib/OpenApi.CSharp/CSharpInlineSchemas.cs
+++ b/lib/OpenApi.CSharp/CSharpInlineSchemas.cs
@@ -37,7 +37,7 @@ public class CSharpInlineSchemas(CSharpSchemaOptions options, DocumentRegistry d
 				new(options.ToArrayType(ToInlineDataType(items).Text), IsEnumerable: true),
 			// Generates a source file, so therefore it must have a class name
 			_ when ProduceSourceEntry(schema) =>
-				new(GetClassName(schema)),
+				new($"global::{options.GetNamespace(schema.Metadata.Id)}.{GetClassName(schema)}"),
 			// Specifically-mapped type
 			{ Type: string type, Format: var format } =>
 				new(options.Find(type, format)),

--- a/lib/OpenApi.CSharp/CSharpInlineSchemas.cs
+++ b/lib/OpenApi.CSharp/CSharpInlineSchemas.cs
@@ -37,7 +37,7 @@ public class CSharpInlineSchemas(CSharpSchemaOptions options, DocumentRegistry d
 				new(options.ToArrayType(ToInlineDataType(items).Text), IsEnumerable: true),
 			// Generates a source file, so therefore it must have a class name
 			_ when ProduceSourceEntry(schema) =>
-				new($"global::{options.GetNamespace(schema.Metadata.Id)}.{GetClassName(schema)}"),
+				new($"global::{options.GetNamespace(schema)}.{GetClassName(schema)}"),
 			// Specifically-mapped type
 			{ Type: string type, Format: var format } =>
 				new(options.Find(type, format)),
@@ -75,7 +75,7 @@ public class CSharpInlineSchemas(CSharpSchemaOptions options, DocumentRegistry d
 
 	private string GetClassName(JsonSchema schema)
 	{
-		return options.ToClassName(schema.Metadata.Id, UriToClassIdentifier(schema.Metadata.Id));
+		return options.ToClassName(schema, UriToClassIdentifier(schema.Metadata.Id));
 	}
 
 	private static readonly Regex HttpSuccessRegex = new Regex("2[0-9]{2}");

--- a/lib/OpenApi.CSharp/CSharpNaming.cs
+++ b/lib/OpenApi.CSharp/CSharpNaming.cs
@@ -37,7 +37,7 @@ namespace DarkPatterns.OpenApi.CSharp
 				string s => char.ToLower(s[0]) + s.Substring(1)
 			};
 
-		public static string? ToNamespace(string? rootNamespace, string? projectDir, string? identity, string? link, IEnumerable<string> reservedIdentifiers)
+		public static string ToNamespace(string? rootNamespace, string? projectDir, string? identity, string? link, IEnumerable<string> reservedIdentifiers)
 		{
 			var prefix = rootNamespace is { Length: > 0 } ? Enumerable.Repeat(rootNamespace, 1) : Enumerable.Empty<string>();
 

--- a/lib/OpenApi.CSharp/CSharpSchemaExtensionsOptions.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaExtensionsOptions.cs
@@ -2,4 +2,6 @@ namespace DarkPatterns.OpenApi.CSharp;
 
 public class CSharpSchemaExtensionsOptions
 {
+	public string TypeNameOverride { get; set; } = "dotnet-type-name";
+	public string NamespaceOverride { get; set; } = "dotnet-type-namespace";
 }

--- a/lib/OpenApi.CSharp/CSharpSchemaExtensionsOptions.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaExtensionsOptions.cs
@@ -1,0 +1,5 @@
+namespace DarkPatterns.OpenApi.CSharp;
+
+public class CSharpSchemaExtensionsOptions
+{
+}

--- a/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
@@ -13,6 +13,7 @@ namespace DarkPatterns.OpenApi.CSharp
 		public string ArrayType { get; set; } = "global::System.Collections.Generic.IEnumerable<{}>";
 		public string FallbackType { get; set; } = "object";
 		public string DefaultNamespace { get; set; } = "";
+		public Dictionary<string, string> OverrideNames { get; set; } = new();
 		public Dictionary<Uri, string> NamespacesBySchema { get; set; } = new();
 		public Dictionary<string, OpenApiTypeFormats> Types { get; } = new();
 
@@ -49,12 +50,14 @@ namespace DarkPatterns.OpenApi.CSharp
 
 		internal string GetNamespace(Uri schemaId)
 		{
+			if (OverrideNames.TryGetValue(schemaId.OriginalString, out var fullName)) return fullName.Substring(0, fullName.LastIndexOf('.'));
 			if (NamespacesBySchema.TryGetValue(schemaId, out var result)) return result;
 			return DefaultNamespace;
 		}
 
 		internal string ToClassName(Uri schemaId, string nameFromFragment)
 		{
+			if (OverrideNames.TryGetValue(schemaId.OriginalString, out var fullName)) return fullName.Substring(fullName.LastIndexOf('.') + 1);
 			return CSharpNaming.ToClassName(nameFromFragment, ReservedIdentifiers());
 		}
 	}

--- a/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,7 +6,7 @@ namespace DarkPatterns.OpenApi.CSharp
 {
 	public class CSharpSchemaOptions
 	{
-		public string ControllerNameExtension { get; set; } = "dotnet-mvc-server-controller";
+		public CSharpSchemaExtensionsOptions Extensions { get; set; } = new();
 		public List<string> GlobalReservedIdentifiers { get; } = new();
 		public Dictionary<string, List<string>> ContextualReservedIdentifiers { get; } = new();
 		public string MapType { get; set; } = "global::System.Collections.Generic.Dictionary<string, {}>";

--- a/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -51,6 +51,11 @@ namespace DarkPatterns.OpenApi.CSharp
 		{
 			if (NamespacesBySchema.TryGetValue(schemaId, out var result)) return result;
 			return DefaultNamespace;
+		}
+
+		internal string ToClassName(Uri schemaId, string nameFromFragment)
+		{
+			return CSharpNaming.ToClassName(nameFromFragment, ReservedIdentifiers());
 		}
 	}
 

--- a/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using DarkPatterns.OpenApi.Transformations.Specifications;
+using DarkPatterns.OpenApi.Transformations.Specifications.Keywords;
 
 namespace DarkPatterns.OpenApi.CSharp
 {
 	public class CSharpSchemaOptions
 	{
-		public CSharpSchemaExtensionsOptions Extensions { get; set; } = new();
+		public virtual CSharpSchemaExtensionsOptions Extensions { get; set; } = new();
 		public List<string> GlobalReservedIdentifiers { get; } = new();
 		public Dictionary<string, List<string>> ContextualReservedIdentifiers { get; } = new();
 		public string MapType { get; set; } = "global::System.Collections.Generic.Dictionary<string, {}>";
@@ -48,16 +51,24 @@ namespace DarkPatterns.OpenApi.CSharp
 				extraReserved
 			);
 
-		internal string GetNamespace(Uri schemaId)
+		internal string GetNamespace(JsonSchema schema)
 		{
+			var schemaId = schema.Metadata.Id;
 			if (OverrideNames.TryGetValue(schemaId.OriginalString, out var fullName)) return fullName.Substring(0, fullName.LastIndexOf('.'));
+			if (schema.TryGetAnnotation<UnknownKeyword>($"x-{Extensions.NamespaceOverride}") is { } nsOverride
+				&& nsOverride.Value?.GetValueKind() == System.Text.Json.JsonValueKind.String)
+				return nsOverride.Value.GetValue<string>();
 			if (NamespacesBySchema.TryGetValue(schemaId, out var result)) return result;
 			return DefaultNamespace;
 		}
 
-		internal string ToClassName(Uri schemaId, string nameFromFragment)
+		internal string ToClassName(JsonSchema schema, string nameFromFragment)
 		{
+			var schemaId = schema.Metadata.Id;
 			if (OverrideNames.TryGetValue(schemaId.OriginalString, out var fullName)) return fullName.Substring(fullName.LastIndexOf('.') + 1);
+			if (schema.TryGetAnnotation<UnknownKeyword>($"x-{Extensions.TypeNameOverride}") is { } typeNameOverride
+				&& typeNameOverride.Value?.GetValueKind() == System.Text.Json.JsonValueKind.String)
+				return typeNameOverride.Value.GetValue<string>();
 			return CSharpNaming.ToClassName(nameFromFragment, ReservedIdentifiers());
 		}
 	}

--- a/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
@@ -12,6 +12,8 @@ namespace DarkPatterns.OpenApi.CSharp
 		public string MapType { get; set; } = "global::System.Collections.Generic.Dictionary<string, {}>";
 		public string ArrayType { get; set; } = "global::System.Collections.Generic.IEnumerable<{}>";
 		public string FallbackType { get; set; } = "object";
+		public string DefaultNamespace { get; set; } = "";
+		public Dictionary<Uri, string> NamespacesBySchema { get; set; } = new();
 		public Dictionary<string, OpenApiTypeFormats> Types { get; } = new();
 
 		internal string Find(string type, string? format)
@@ -44,6 +46,12 @@ namespace DarkPatterns.OpenApi.CSharp
 			).Concat(
 				extraReserved
 			);
+
+		internal string GetNamespace(Uri schemaId)
+		{
+			if (NamespacesBySchema.TryGetValue(schemaId, out var result)) return result;
+			return DefaultNamespace;
+		}
 	}
 
 	public class OpenApiTypeFormats

--- a/lib/OpenApi.CSharp/CSharpSchemaSourceProvider.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaSourceProvider.cs
@@ -21,17 +21,15 @@ public class CSharpSchemaSourceProvider : SchemaSourceProvider
 	private readonly DocumentRegistry documentRegistry;
 	private readonly ISchemaRegistry schemaRegistry;
 	private readonly CSharpInlineSchemas inlineSchemas;
-	private readonly string baseNamespace;
 	private readonly CSharpSchemaOptions options;
 	private readonly HandlebarsFactory handlebarsFactory;
 	private readonly PartialHeader header;
 
-	public CSharpSchemaSourceProvider(DocumentRegistry documentRegistry, ISchemaRegistry schemaRegistry, string baseNamespace, CSharpSchemaOptions options, HandlebarsFactory handlebarsFactory, Templates.PartialHeader header) : base(schemaRegistry)
+	public CSharpSchemaSourceProvider(DocumentRegistry documentRegistry, ISchemaRegistry schemaRegistry, CSharpSchemaOptions options, HandlebarsFactory handlebarsFactory, Templates.PartialHeader header) : base(schemaRegistry)
 	{
 		this.documentRegistry = documentRegistry;
 		this.schemaRegistry = schemaRegistry;
 		this.inlineSchemas = new CSharpInlineSchemas(options, documentRegistry);
-		this.baseNamespace = baseNamespace;
 		this.options = options;
 		this.handlebarsFactory = handlebarsFactory;
 		this.header = header;
@@ -40,7 +38,7 @@ public class CSharpSchemaSourceProvider : SchemaSourceProvider
 	protected override SourceEntry? GetSourceEntry(JsonSchema entry, OpenApiTransformDiagnostic diagnostic)
 	{
 		if (!inlineSchemas.ProduceSourceEntry(entry)) return null;
-		var targetNamespace = baseNamespace;
+		var targetNamespace = options.GetNamespace(entry.Metadata.Id);
 		var className = GetClassName(entry);
 
 		Templates.Model? model = GetModel(entry, diagnostic, className);

--- a/lib/OpenApi.CSharp/CSharpSchemaSourceProvider.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaSourceProvider.cs
@@ -47,6 +47,7 @@ public class CSharpSchemaSourceProvider : SchemaSourceProvider
 		var sourceText = HandlebarsTemplateProcess.ProcessModel(
 			header: header,
 			packageName: targetNamespace,
+			schemaId: entry.Metadata.Id,
 			model: model,
 			handlebarsFactory.Handlebars
 		);

--- a/lib/OpenApi.CSharp/CSharpSchemaSourceProvider.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaSourceProvider.cs
@@ -38,7 +38,7 @@ public class CSharpSchemaSourceProvider : SchemaSourceProvider
 	protected override SourceEntry? GetSourceEntry(JsonSchema entry, OpenApiTransformDiagnostic diagnostic)
 	{
 		if (!inlineSchemas.ProduceSourceEntry(entry)) return null;
-		var targetNamespace = options.GetNamespace(entry.Metadata.Id);
+		var targetNamespace = options.GetNamespace(entry);
 		var className = GetClassName(entry);
 
 		Templates.Model? model = GetModel(entry, diagnostic, className);
@@ -97,11 +97,8 @@ public class CSharpSchemaSourceProvider : SchemaSourceProvider
 		return null;
 	}
 
-	private string GetClassName(JsonSchema schema)
-	{
-		var context = schema.Metadata.Id;
-		return CSharpNaming.ToClassName(inlineSchemas.UriToClassIdentifier(context), options.ReservedIdentifiers());
-	}
+	private string GetClassName(JsonSchema schema) =>
+		options.ToClassName(schema, inlineSchemas.UriToClassIdentifier(schema.Metadata.Id));
 
 	record ObjectModel(Func<IReadOnlyDictionary<string, JsonSchema>> Properties, Func<IEnumerable<string>> Required, bool LegacyOptionalBehavior);
 

--- a/lib/OpenApi.CSharp/HandlebarsTemplateProcess.cs
+++ b/lib/OpenApi.CSharp/HandlebarsTemplateProcess.cs
@@ -47,6 +47,7 @@ namespace DarkPatterns.OpenApi.CSharp
 		public static string ProcessModel(
 			PartialHeader header,
 			string packageName,
+			Uri schemaId,
 			Model model,
 			IHandlebars? handlebars = null
 		)
@@ -68,7 +69,7 @@ namespace DarkPatterns.OpenApi.CSharp
 			IDictionary<string, object?> ToTemplate<TModel>(TModel m)
 				where TModel : Model
 			{
-				return ToDictionary<ModelTemplate<TModel>>(new(Header: header, PackageName: packageName, Model: m));
+				return ToDictionary<ModelTemplate<TModel>>(new(Header: header, PackageName: packageName, SourceSchemaId: schemaId.OriginalString, Model: m));
 			}
 		}
 

--- a/lib/OpenApi.CSharp/Templates/Model.cs
+++ b/lib/OpenApi.CSharp/Templates/Model.cs
@@ -10,6 +10,7 @@ namespace DarkPatterns.OpenApi.CSharp.Templates
 		PartialHeader Header,
 
 		string PackageName,
+		string SourceSchemaId,
 
 		TModel Model
 	) where TModel : Model;

--- a/lib/OpenApi.CSharp/Templates/enumModel.handlebars
+++ b/lib/OpenApi.CSharp/Templates/enumModel.handlebars
@@ -3,6 +3,7 @@
 #nullable disable warnings
 #pragma warning disable
 
+// Generated from schema: {{this.SourceSchemaId}}
 namespace {{this.PackageName}}
 { {{#with Model as |Model|}}{{#if Description}}
     /// <summary>

--- a/lib/OpenApi.CSharp/Templates/objectmodel.handlebars
+++ b/lib/OpenApi.CSharp/Templates/objectmodel.handlebars
@@ -3,6 +3,7 @@
 #nullable enable
 #nullable disable warnings
 
+// Generated from schema: {{this.SourceSchemaId}}
 namespace {{this.PackageName}}
 {
     {{#with Model}}

--- a/lib/OpenApi.CSharp/Templates/typeUnionModel.handlebars
+++ b/lib/OpenApi.CSharp/Templates/typeUnionModel.handlebars
@@ -3,6 +3,7 @@
 #nullable disable warnings
 #pragma warning disable
 
+// Generated from schema: {{this.SourceSchemaId}}
 namespace {{this.PackageName}}
 { {{#with Model as |Model|}}{{#if Description}}
     /// <summary>

--- a/lib/OpenApi.CSharp/csharp.config.yaml
+++ b/lib/OpenApi.CSharp/csharp.config.yaml
@@ -1,5 +1,4 @@
-﻿controllerNameExtension: dotnet-mvc-server-controller
-globalReservedIdentifiers:
+﻿globalReservedIdentifiers:
   - 'string'
   - 'bool'
   - 'double'

--- a/lib/OpenApi.CSharp/csharp.config.yaml
+++ b/lib/OpenApi.CSharp/csharp.config.yaml
@@ -1,4 +1,7 @@
-﻿globalReservedIdentifiers:
+﻿extensions:
+  namespaceOverride: dotnet-type-namespace
+  typeNameOverride: dotnet-type-name
+globalReservedIdentifiers:
   - 'string'
   - 'bool'
   - 'double'

--- a/lib/OpenApi.Transformations/DocumentResolverFactory.cs
+++ b/lib/OpenApi.Transformations/DocumentResolverFactory.cs
@@ -20,6 +20,7 @@ public static class DocumentResolverFactory
 	{
 		return (baseUri, _) =>
 		{
+			if (baseUri != uri) return null;
 			using var sr = new StringReader(documentContents);
 			return docLoader.LoadDocument(uri, sr, null);
 		};

--- a/lib/OpenApi.Transformations/DocumentResolverFactory.cs
+++ b/lib/OpenApi.Transformations/DocumentResolverFactory.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using DarkPatterns.OpenApi.Transformations.Diagnostics;
 using DarkPatterns.OpenApi.Transformations.DocumentTypes;
+using DarkPatterns.OpenApiCodegen;
 
 namespace DarkPatterns.OpenApi.Transformations;
 
@@ -14,6 +15,15 @@ public record DocumentRegistryOptions(
 public static class DocumentResolverFactory
 {
 	private static readonly YamlDocumentLoader docLoader = new YamlDocumentLoader();
+
+	public static DocumentResolver LoadAs(Uri uri, string documentContents)
+	{
+		return (baseUri, _) =>
+		{
+			using var sr = new StringReader(documentContents);
+			return docLoader.LoadDocument(uri, sr, null);
+		};
+	}
 
 	public static DocumentResolver RelativeFrom(IDocumentReference documentReference)
 	{

--- a/lib/OpenApi.Transformations/Specifications/IJsonSchemaDialect.cs
+++ b/lib/OpenApi.Transformations/Specifications/IJsonSchemaDialect.cs
@@ -8,14 +8,14 @@ namespace DarkPatterns.OpenApi.Transformations.Specifications;
 public interface IJsonSchemaDialect
 {
 	Uri Id { get; }
-	string IdField { get; }
+	string? IdField { get; }
 	IReadOnlyCollection<IJsonSchemaVocabulary> Vocabularies { get; }
 	IJsonSchemaKeyword UnknownKeyword { get; }
 }
 
 public record JsonSchemaDialect(
 	Uri Id,
-	string IdField,
+	string? IdField,
 	IReadOnlyCollection<IJsonSchemaVocabulary> Vocabularies,
 	IJsonSchemaKeyword UnknownKeyword
 ) : IJsonSchemaDialect

--- a/lib/OpenApi.Transformations/Specifications/OpenApi3_0/OpenApi3_0DocumentFactory.cs
+++ b/lib/OpenApi.Transformations/Specifications/OpenApi3_0/OpenApi3_0DocumentFactory.cs
@@ -97,7 +97,7 @@ public class OpenApi3_0DocumentFactory : IOpenApiDocumentFactory
 		OpenApiDialect =
 			new JsonSchemaDialect(
 				jsonSchemaDialect,
-				"id",
+				null,
 				[
 					Vocabulary,
 					// should be all of "https://spec.openapis.org/oas/3.0/schema/2021-09-28"

--- a/lib/OpenApiCodegen.Client.CSharp.Test/DynamicCompilation.cs
+++ b/lib/OpenApiCodegen.Client.CSharp.Test/DynamicCompilation.cs
@@ -45,7 +45,7 @@ namespace DarkPatterns.OpenApiCodegen.Client.CSharp
 			var options = LoadOptions();
 			configureOptions?.Invoke(options);
 
-			var transformer = document.BuildCSharpClientSourceProvider(registry, "", "DPD.Controller", options);
+			var transformer = document.BuildCSharpClientSourceProvider(registry, "", options);
 			OpenApiTransformDiagnostic diagnostic = new();
 
 			var entries = transformer.GetSources(diagnostic).ToArray();

--- a/lib/OpenApiCodegen.Client.CSharp.Test/OptionsHelpers.cs
+++ b/lib/OpenApiCodegen.Client.CSharp.Test/OptionsHelpers.cs
@@ -16,6 +16,7 @@ namespace DarkPatterns.OpenApiCodegen.Client.CSharp
 			configureBuilder?.Invoke(builder);
 			var result = builder.Build().Get<CSharpSchemaOptions>()
 					?? throw new InvalidOperationException("Could not construct options");
+			result.DefaultNamespace = "DPD.Controller";
 			return result;
 		}
 	}

--- a/lib/OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
+++ b/lib/OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
@@ -51,8 +51,8 @@ public class CSharpInlineSchemasShould
 	}
 
 	[Theory]
-	[InlineData("FindPetsByStatusStatusItem", "petstore3.json", "/paths/~1pet~1findByStatus/get/parameters/0/schema/items")]
-	[InlineData("DifficultQueryStringEnumEnum", "enum.yaml", "/paths/~1difficult-enum/get/parameters/0/schema")]
+	[InlineData("global::DPD.Controller.FindPetsByStatusStatusItem", "petstore3.json", "/paths/~1pet~1findByStatus/get/parameters/0/schema/items")]
+	[InlineData("global::DPD.Controller.DifficultQueryStringEnumEnum", "enum.yaml", "/paths/~1difficult-enum/get/parameters/0/schema")]
 	public void Determine_a_name_for_schema_by_path(string expectedName, string documentName, string path)
 	{
 		var docResult = GetDocumentReference(documentName);

--- a/lib/OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
+++ b/lib/OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
@@ -67,6 +67,27 @@ public class CSharpInlineSchemasShould
 		Assert.Equal(expectedName, actual?.Text);
 	}
 
+	[Fact]
+	public void Determine_a_name_for_schema_with_override()
+	{
+		string expectedName = "global::My.TestEnum";
+		string documentName = "enum.yaml";
+		string path = "/paths/~1difficult-enum/get/parameters/0/schema";
+
+		var docResult = GetDocumentReference(documentName);
+		Assert.NotNull(docResult);
+		var (registry, document, schema) = GetSchema(docResult, path);
+		var opt = LoadOptions();
+		opt.OverrideNames[schema!.Metadata.Id.OriginalString] = "My.TestEnum";
+		var target = CreateTarget(opt, registry);
+
+		Assert.NotNull(schema);
+
+		var actual = target.ToInlineDataType(schema!);
+
+		Assert.Equal(expectedName, actual?.Text);
+	}
+
 	private static (DocumentRegistry registry, OpenApiDocument? document, JsonSchema? schema) GetSchema(IDocumentReference docRef, string path)
 	{
 		var registry = DocumentLoader.CreateRegistry();

--- a/lib/OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
+++ b/lib/OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
@@ -53,6 +53,7 @@ public class CSharpInlineSchemasShould
 	[Theory]
 	[InlineData("global::DPD.Controller.FindPetsByStatusStatusItem", "petstore3.json", "/paths/~1pet~1findByStatus/get/parameters/0/schema/items")]
 	[InlineData("global::DPD.Controller.DifficultQueryStringEnumEnum", "enum.yaml", "/paths/~1difficult-enum/get/parameters/0/schema")]
+	[InlineData("global::DPD.Controller.TreeNode", "csharp-name-override.yaml", "/components/schemas/Node")]
 	public void Determine_a_name_for_schema_by_path(string expectedName, string documentName, string path)
 	{
 		var docResult = GetDocumentReference(documentName);

--- a/lib/OpenApiCodegen.Server.Mvc.Test/ComprehensiveTransformsShould.cs
+++ b/lib/OpenApiCodegen.Server.Mvc.Test/ComprehensiveTransformsShould.cs
@@ -44,7 +44,7 @@ namespace DarkPatterns.OpenApiCodegen.Server.Mvc
 			Assert.NotNull(docResult.Document);
 			var options = LoadOptions();
 
-			var transformer = docResult.Document.BuildCSharpPathControllerSourceProvider(registry, "", "DPD.Controller", options);
+			var transformer = docResult.Document.BuildCSharpPathControllerSourceProvider(registry, "", options);
 			OpenApiTransformDiagnostic diagnostic = new();
 
 			try

--- a/lib/OpenApiCodegen.Server.Mvc.Test/DynamicCompilation.cs
+++ b/lib/OpenApiCodegen.Server.Mvc.Test/DynamicCompilation.cs
@@ -49,7 +49,7 @@ namespace DarkPatterns.OpenApiCodegen.Server.Mvc
 			Assert.NotNull(docResult.Document);
 			var options = LoadOptions();
 
-			var transformer = docResult.Document.BuildCSharpPathControllerSourceProvider(registry, "", "DPD.Controller", options);
+			var transformer = docResult.Document.BuildCSharpPathControllerSourceProvider(registry, "", options);
 			OpenApiTransformDiagnostic diagnostic = new();
 
 			var entries = transformer.GetSources(diagnostic).ToArray();

--- a/lib/OpenApiCodegen.Server.Mvc.Test/OptionsHelpers.cs
+++ b/lib/OpenApiCodegen.Server.Mvc.Test/OptionsHelpers.cs
@@ -16,6 +16,7 @@ namespace DarkPatterns.OpenApiCodegen.Server.Mvc
 			configureBuilder?.Invoke(builder);
 			var result = builder.Build().Get<CSharpServerSchemaOptions>();
 			if (result == null) throw new InvalidOperationException("Could not load default test");
+			result.DefaultNamespace = "DPD.Controller";
 			return result;
 		}
 	}

--- a/lib/OpenApiCodegen/IOpenApiCodeGenerator.cs
+++ b/lib/OpenApiCodegen/IOpenApiCodeGenerator.cs
@@ -19,6 +19,8 @@ public record DiagnosticLocation(string FilePath, DiagnosticLocationRange? Range
 
 public record DiagnosticInfo(string Id, DiagnosticLocation Location, IReadOnlyList<string> Metadata);
 
+public record AdditionalTextInfo(string Path, string Contents, IReadOnlyDictionary<string, string?> Metadata);
+
 public record GenerationResult(IReadOnlyList<SourceEntry> Sources, IReadOnlyList<DiagnosticInfo> Diagnostics);
 
 // Note: This interface is not used directly, but is used by the `BaseGenerator` via reflection/compiled lambdas
@@ -26,5 +28,6 @@ public interface IOpenApiCodeGenerator
 {
 	IEnumerable<string> MetadataKeys { get; }
 
-	GenerationResult Generate(string documentPath, string documentContents, IReadOnlyDictionary<string, string?> additionalTextMetadata);
+	AdditionalTextInfo ToFileInfo(string documentPath, string documentContents, IReadOnlyDictionary<string, string?> additionalTextMetadata);
+	GenerationResult Generate(AdditionalTextInfo entrypoint, IEnumerable<AdditionalTextInfo> other);
 }

--- a/lib/TestApp.Test/MultiFileRefYamlShould.cs
+++ b/lib/TestApp.Test/MultiFileRefYamlShould.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace DarkPatterns.OpenApiCodegen.Server.Mvc.TestApp;
+
+using static Utilities;
+
+public class MultiFileRefYamlShould
+{
+
+	[Fact]
+	public Task HandleAllOfResponses() =>
+		TestSingleRequest<MultiFileRef.RandomControllerBase.GetRandomActionResult>(new(
+			MultiFileRef.RandomControllerBase.GetRandomActionResult.BadRequest(new MultiFileRef.Types.BadRequest(Code: "ERR-123", Message: "Mocked error")),
+			client => client.GetAsync("/multi-file-ref/random")
+		)
+		{
+			AssertResponseMessage = VerifyResponse(400, new { code = "ERR-123", message = "Mocked error" }),
+		});
+}

--- a/lib/TestApp/MultiFileRef/Controllers.cs
+++ b/lib/TestApp/MultiFileRef/Controllers.cs
@@ -1,0 +1,12 @@
+
+
+namespace DarkPatterns.OpenApiCodegen.Server.Mvc.TestApp.MultiFileRef;
+
+public class RandomController : RandomControllerBase
+{
+	protected override Task<GetRandomActionResult> GetRandom()
+	{
+		this.DelegateRequest();
+		return this.DelegateResponse<GetRandomActionResult>();
+	}
+}

--- a/lib/TestApp/OpenApiCodegen.Server.Mvc.TestApp.csproj
+++ b/lib/TestApp/OpenApiCodegen.Server.Mvc.TestApp.csproj
@@ -14,6 +14,7 @@
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\all-of.yaml" Link="AllOf\all-of.yaml" PathPrefix="/all-of" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\enum.yaml" Link="Enum\enum.yaml" PathPrefix="/enum" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\controller-extension.yaml" Link="ControllerExtensions\controller-extension.yaml" PathPrefix="/controller-extensions" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\csharp-name-override.yaml" Link="CSharpNameOverride\csharp-name-override.yaml" PathPrefix="/csharp-name-override" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\validation-min-max.yaml" Link="ValidationMinMax\validation-min-max.yaml" PathPrefix="/validation-min-max" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\regex-escape.yaml" Link="RegexEscape\regex-escape.yaml" PathPrefix="/regex-escape" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\headers.yaml" Link="Headers\headers.yaml" PathPrefix="/headers" />

--- a/lib/TestApp/OpenApiCodegen.Server.Mvc.TestApp.csproj
+++ b/lib/TestApp/OpenApiCodegen.Server.Mvc.TestApp.csproj
@@ -11,19 +11,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\all-of.yaml" Link="AllOf\all-of.yaml" Key="AllOf" PathPrefix="/all-of" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\enum.yaml" Link="Enum\enum.yaml" Key="Enum" PathPrefix="/enum" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\controller-extension.yaml" Link="ControllerExtensions\controller-extension.yaml" Key="ControllerExtensions" PathPrefix="/controller-extensions" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\validation-min-max.yaml" Link="ValidationMinMax\validation-min-max.yaml" Key="ValidationMinMax" PathPrefix="/validation-min-max" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\regex-escape.yaml" Link="RegexEscape\regex-escape.yaml" Key="RegexEscape" PathPrefix="/regex-escape" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\headers.yaml" Link="Headers\headers.yaml" Key="Headers" PathPrefix="/headers" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\oauth.yaml" Link="OAuth\oauth.yaml" Key="OAuth" PathPrefix="/oauth" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\form.yaml" Link="Form\form.yaml" Key="Form" PathPrefix="/form" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\one-of.yaml" Link="OneOf\one-of.yaml" Key="OneOf" PathPrefix="/one-of" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\nullable-vs-optional-legacy.yaml" Link="LegacyOptional\nullable-vs-optional-legacy.yaml" Key="LegacyOptional" PathPrefix="/nullable-vs-optional-legacy" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\nullable-vs-optional.yaml" Link="NullableVsOptional\nullable-vs-optional.yaml" Key="NullableVsOptional" PathPrefix="/nullable-vs-optional" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\annotations.yaml" Link="Annotations\annotations.yaml" Key="Annotations" PathPrefix="/annotations" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\response-ref.yaml" Link="ResponseRef\response-ref.yaml" Key="ResponseRef" PathPrefix="/response-ref" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\all-of.yaml" Link="AllOf\all-of.yaml" PathPrefix="/all-of" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\enum.yaml" Link="Enum\enum.yaml" PathPrefix="/enum" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\controller-extension.yaml" Link="ControllerExtensions\controller-extension.yaml" PathPrefix="/controller-extensions" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\validation-min-max.yaml" Link="ValidationMinMax\validation-min-max.yaml" PathPrefix="/validation-min-max" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\regex-escape.yaml" Link="RegexEscape\regex-escape.yaml" PathPrefix="/regex-escape" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\headers.yaml" Link="Headers\headers.yaml" PathPrefix="/headers" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\oauth.yaml" Link="OAuth\oauth.yaml" PathPrefix="/oauth" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\form.yaml" Link="Form\form.yaml" PathPrefix="/form" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\one-of.yaml" Link="OneOf\one-of.yaml" PathPrefix="/one-of" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\nullable-vs-optional-legacy.yaml" Link="LegacyOptional\nullable-vs-optional-legacy.yaml" PathPrefix="/nullable-vs-optional-legacy" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\nullable-vs-optional.yaml" Link="NullableVsOptional\nullable-vs-optional.yaml" PathPrefix="/nullable-vs-optional" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\annotations.yaml" Link="Annotations\annotations.yaml" PathPrefix="/annotations" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\response-ref.yaml" Link="ResponseRef\response-ref.yaml" PathPrefix="/response-ref" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\multi-file-ref.yaml" Link="MultiFileRef\multi-file-ref.yaml" PathPrefix="/multi-file-ref" />
+    <JsonSchemaDocument Include="$(SolutionRoot)schemas\multi-file-ref-types.yaml" Link="MultiFileRef\Types\multi-file-ref-types.yaml" />
+    <JsonSchemaDocument Include="$(SolutionRoot)schemas\multi-file-ref-responses.yaml" Link="MultiFileRef\Responses\multi-file-ref-responses.yaml" />
 
     <Compile Remove="generated/**/*" />
     <Clean Include="generated/**/*" />

--- a/lib/TestApp/OpenApiCodegen.Server.Mvc.TestApp.csproj
+++ b/lib/TestApp/OpenApiCodegen.Server.Mvc.TestApp.csproj
@@ -24,9 +24,9 @@
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\nullable-vs-optional.yaml" Link="NullableVsOptional\nullable-vs-optional.yaml" PathPrefix="/nullable-vs-optional" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\annotations.yaml" Link="Annotations\annotations.yaml" PathPrefix="/annotations" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\response-ref.yaml" Link="ResponseRef\response-ref.yaml" PathPrefix="/response-ref" />
-    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\multi-file-ref.yaml" Link="MultiFileRef\multi-file-ref.yaml" PathPrefix="/multi-file-ref" />
-    <JsonSchemaDocument Include="$(SolutionRoot)schemas\multi-file-ref-types.yaml" Link="MultiFileRef\Types\multi-file-ref-types.yaml" />
-    <JsonSchemaDocument Include="$(SolutionRoot)schemas\multi-file-ref-responses.yaml" Link="MultiFileRef\Responses\multi-file-ref-responses.yaml" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\multi-file-ref.yaml" Link="MultiFileRef\multi-file-ref.yaml" PathPrefix="/multi-file-ref" SchemaId="proj://darkpatterns-openapi/multi-file-ref.yaml" />
+    <JsonSchemaDocument Include="$(SolutionRoot)schemas\multi-file-ref-types.yaml" Link="MultiFileRef\Types\multi-file-ref-types.yaml" SchemaId="proj://darkpatterns-openapi/multi-file-ref-types.yaml" />
+    <JsonSchemaDocument Include="$(SolutionRoot)schemas\multi-file-ref-responses.yaml" Link="MultiFileRef\Responses\multi-file-ref-responses.yaml" SchemaId="proj://darkpatterns-openapi/multi-file-ref-responses.yaml" />
 
     <Compile Remove="generated/**/*" />
     <Clean Include="generated/**/*" />

--- a/schemas/csharp-name-override.yaml
+++ b/schemas/csharp-name-override.yaml
@@ -1,0 +1,28 @@
+openapi: "3.0.3"
+info:
+  version: 1.0.0
+  title: CSharp Name Override example
+  description: A sample API that demonstrates how names and namespaces can be overridden
+components:
+  schemas:
+    Node:
+      x-dotnet-type-name: TreeNode
+      type: object
+      required:
+        - children
+      properties:
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'
+paths:
+  /tree:
+    post:
+      operationId: getTree
+      responses:
+        '200':
+          description: A tree
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'

--- a/schemas/multi-file-ref-responses.yaml
+++ b/schemas/multi-file-ref-responses.yaml
@@ -1,0 +1,21 @@
+components:
+  responses:
+    Number:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: integer
+    BadRequest:
+      description: unexpected error
+      content:
+        application/json:
+          schema:
+            $ref: 'multi-file-ref-types.yaml#/BadRequest'
+    Unknown:
+      description: unexpected error
+      content:
+        application/json:
+          schema:
+            type: object
+            format: any

--- a/schemas/multi-file-ref-types.yaml
+++ b/schemas/multi-file-ref-types.yaml
@@ -1,0 +1,10 @@
+BadRequest:
+  type: object
+  required:
+    - code
+    - message
+  properties:
+    code:
+      type: string
+    message:
+      type: string

--- a/schemas/multi-file-ref.yaml
+++ b/schemas/multi-file-ref.yaml
@@ -1,0 +1,16 @@
+openapi: "3.0.3"
+info:
+  version: 1.0.0
+  title: Multi File Ref Demo
+  description: A sample API that uses references from other files
+paths:
+  /random:
+    get:
+      operationId: getRandom
+      responses:
+        '200':
+          $ref: 'multi-file-ref-responses.yaml#/components/responses/Number'
+        '400':
+          $ref: 'multi-file-ref-responses.yaml#/components/responses/BadRequest'
+        default:
+          $ref: 'multi-file-ref-responses.yaml#/components/responses/Unknown'


### PR DESCRIPTION
- Allows specifying the schema ID for an OpenAPI document within the csproj
- Multi-file schema systems can now support namespace changes per-file within the csproj
- Allows overriding C# namespaces and type names from within the schema themselves