### PR TITLE
Bugfix: Correct support for URI in configuration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,8 +30,8 @@
 
 	<PropertyGroup>
 		<OpenApiJsonExtensionsVersion>0.17.1</OpenApiJsonExtensionsVersion>
-		<OpenApiMvcServerVersion>0.18.0</OpenApiMvcServerVersion>
-		<OpenApiCSharpClientVersion>0.18.0</OpenApiCSharpClientVersion>
+		<OpenApiMvcServerVersion>0.18.1</OpenApiMvcServerVersion>
+		<OpenApiCSharpClientVersion>0.18.1</OpenApiCSharpClientVersion>
 		<OpenApiTypeScriptClientVersion>0.10.0</OpenApiTypeScriptClientVersion>
 		<OpenApiTypeScriptRxjsClientVersion>0.8.1</OpenApiTypeScriptRxjsClientVersion>
 		<OpenApiTypeScriptMswVersion>0.8.1</OpenApiTypeScriptMswVersion>

--- a/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
+++ b/lib/OpenApi.CSharp/CSharpSchemaOptions.cs
@@ -54,7 +54,8 @@ namespace DarkPatterns.OpenApi.CSharp
 		internal string GetNamespace(JsonSchema schema)
 		{
 			var schemaId = schema.Metadata.Id;
-			if (OverrideNames.TryGetValue(schemaId.OriginalString, out var fullName)) return fullName.Substring(0, fullName.LastIndexOf('.'));
+			// This is a hack to avoid lack of support for https://github.com/dotnet/runtime/issues/67616
+			if (OverrideNames.TryGetValue(schemaId.OriginalString.Replace(':', '#'), out var fullName)) return fullName.Substring(0, fullName.LastIndexOf('.'));
 			if (schema.TryGetAnnotation<UnknownKeyword>($"x-{Extensions.NamespaceOverride}") is { } nsOverride
 				&& nsOverride.Value?.GetValueKind() == System.Text.Json.JsonValueKind.String)
 				return nsOverride.Value.GetValue<string>();
@@ -65,7 +66,8 @@ namespace DarkPatterns.OpenApi.CSharp
 		internal string ToClassName(JsonSchema schema, string nameFromFragment)
 		{
 			var schemaId = schema.Metadata.Id;
-			if (OverrideNames.TryGetValue(schemaId.OriginalString, out var fullName)) return fullName.Substring(fullName.LastIndexOf('.') + 1);
+			// This is a hack to avoid lack of support for https://github.com/dotnet/runtime/issues/67616
+			if (OverrideNames.TryGetValue(schemaId.OriginalString.Replace(':', '#'), out var fullName)) return fullName.Substring(fullName.LastIndexOf('.') + 1);
 			if (schema.TryGetAnnotation<UnknownKeyword>($"x-{Extensions.TypeNameOverride}") is { } typeNameOverride
 				&& typeNameOverride.Value?.GetValueKind() == System.Text.Json.JsonValueKind.String)
 				return typeNameOverride.Value.GetValue<string>();

--- a/lib/OpenApi.Transformations/Configuration/YamlConfigurationFileParser.cs
+++ b/lib/OpenApi.Transformations/Configuration/YamlConfigurationFileParser.cs
@@ -36,7 +36,8 @@ namespace DarkPatterns.OpenApi.Transformations.Configuration
 
 		private void VisitYamlNodePair(KeyValuePair<YamlNode, YamlNode> yamlNodePair)
 		{
-			var context = ((YamlScalarNode)yamlNodePair.Key).Value!;
+			// This is a hack to avoid lack of support for https://github.com/dotnet/runtime/issues/67616
+			var context = ((YamlScalarNode)yamlNodePair.Key).Value!.Replace(':', '#');
 			VisitYamlNode(context, yamlNodePair.Value);
 		}
 

--- a/lib/OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
+++ b/lib/OpenApiCodegen.Server.Mvc.Test/CSharpSchemaTransformerShould.cs
@@ -1,16 +1,13 @@
-﻿using Bogus;
-using Json.Pointer;
-using DarkPatterns.OpenApi.CSharp;
+﻿using DarkPatterns.OpenApi.CSharp;
 using DarkPatterns.OpenApi.Transformations;
 using DarkPatterns.OpenApi.Transformations.Abstractions;
 using DarkPatterns.OpenApi.Transformations.DocumentTypes;
 using DarkPatterns.OpenApi.Transformations.Specifications;
-using DarkPatterns.OpenApi.Transformations.Specifications.Keywords.Draft2020_12Applicator;
 using DarkPatterns.OpenApiCodegen.TestUtils;
+using Microsoft.Extensions.Configuration;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Text;
 using System.Text.Json.Nodes;
 using Xunit;
 using static DarkPatterns.OpenApiCodegen.TestUtils.DocumentHelpers;
@@ -18,7 +15,7 @@ using static DarkPatterns.OpenApiCodegen.TestUtils.DocumentHelpers;
 namespace DarkPatterns.OpenApiCodegen.Server.Mvc;
 using static OptionsHelpers;
 
-public class CSharpInlineSchemasShould
+public class CSharpSchemaTransformerShould
 {
 	private CSharpInlineSchemas CreateTarget(CSharpServerSchemaOptions options, DocumentRegistry registry) => new(options, registry);
 
@@ -78,8 +75,13 @@ public class CSharpInlineSchemasShould
 		var docResult = GetDocumentReference(documentName);
 		Assert.NotNull(docResult);
 		var (registry, document, schema) = GetSchema(docResult, path);
-		var opt = LoadOptions();
-		opt.OverrideNames[schema!.Metadata.Id.OriginalString] = "My.TestEnum";
+		var opt = LoadOptions(configurationBuilder =>
+		{
+			configurationBuilder.AddYamlStream(new MemoryStream(Encoding.UTF8.GetBytes($@"
+overrideNames:
+  {schema!.Metadata.Id.OriginalString}: My.TestEnum
+")));
+		});
 		var target = CreateTarget(opt, registry);
 
 		Assert.NotNull(schema);


### PR DESCRIPTION
.NET reserves the character `:` for keys in configurations. This adds a hack to avoid that and solve the bug where the `overrideNames` did not function as documented.