### PR TITLE
Correct configuration support and client docs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
 		<OpenApiAbstractionsVersion>0.1.0</OpenApiAbstractionsVersion>
 		<OpenApiJsonExtensionsVersion>0.17.1</OpenApiJsonExtensionsVersion>
 		<OpenApiLoadersVersion>0.1.0</OpenApiLoadersVersion>
-		<OpenApiCSharpVersion>0.20.0</OpenApiCSharpVersion>
+		<OpenApiCSharpVersion>0.20.1</OpenApiCSharpVersion>
 		<OpenApiTypeScriptClientVersion>0.11.0</OpenApiTypeScriptClientVersion>
 		<OpenApiTypeScriptRxjsClientVersion>0.8.1</OpenApiTypeScriptRxjsClientVersion>
 		<OpenApiTypeScriptMswVersion>0.8.1</OpenApiTypeScriptMswVersion>

--- a/examples/dotnetcore-server-interfaces/ServerInterfacesExample/ServerInterfacesExample.csproj
+++ b/examples/dotnetcore-server-interfaces/ServerInterfacesExample/ServerInterfacesExample.csproj
@@ -7,14 +7,6 @@
 	<Import Project="$(SolutionRoot)examples\dotnetcore-server-interfaces\tooling\server-generator-references.props" />
 
 	<ItemGroup>
-		<None Remove="csharp.config.yaml" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<OpenApiSchemaCSharpServerOptions Include="csharp.config.yaml" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\petstore.yaml" Link="Controllers\petstore.yaml" />
 	</ItemGroup>
 </Project>

--- a/examples/dotnetcore-server-interfaces/tooling/server-generator-references.props
+++ b/examples/dotnetcore-server-interfaces/tooling/server-generator-references.props
@@ -16,7 +16,7 @@
 		<ProjectReference Include="$(SolutionRoot)lib\OpenApiCodegen.Json.Extensions\OpenApiCodegen.Json.Extensions.csproj" />
 
 		<ProjectReference
-			Include="$(SolutionRoot)generators\dotnetcore-server-interfaces\OpenApiCodegen.CSharp.Analyzers\OpenApiCodegen.CSharp.Roslyn3.11.csproj"
+			Include="$(SolutionRoot)generators\csharp\OpenApiCodegen.CSharp.Analyzers\OpenApiCodegen.CSharp.Roslyn3.11.csproj"
 			OutputItemType="Analyzer"
 			ReferenceOutputAssembly="false" />
 		<!-- Not an analyzer, but the project-reference analyzer needs all child dependencies, too -->
@@ -28,6 +28,6 @@
 
 	<!-- When using project references, props/targets that are in the NuGet package don't get automatically picked up -->
 	<Import Condition=" '$(UseProjectReferences)' == 'true' "
-		Project="$(SolutionRoot)generators\dotnetcore-server-interfaces\OpenApiCodegen.CSharp\OpenApiCodegen.CSharp.props" />
+		Project="$(SolutionRoot)generators\csharp\OpenApiCodegen.CSharp\OpenApiCodegen.CSharp.props" />
 
 </Project>

--- a/generators/csharp/OpenApiCodegen.CSharp.Analyzers/OpenApiCSharpGenerator.cs
+++ b/generators/csharp/OpenApiCodegen.CSharp.Analyzers/OpenApiCSharpGenerator.cs
@@ -16,6 +16,7 @@ public sealed class OpenApiCSharpGenerator() : BaseGenerator("DarkPatterns.OpenA
 	private const string includeKey = "DPDInclude";
 	private const string mvcServerType = "DPDGenerateMvcServer";
 	private const string clientType = "DPDGenerateClient";
+	private const string configType = "DPDSchemaOptions";
 	private static readonly DiagnosticDescriptor IncludeDependentDll = new DiagnosticDescriptor(id: "DPDAPI001",
 																								title: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",
 																								messageFormat: "Include a reference to DarkPatterns.OpenApiCodegen.Json.Extensions",
@@ -38,6 +39,7 @@ public sealed class OpenApiCSharpGenerator() : BaseGenerator("DarkPatterns.OpenA
 			.. IfHasProperty(includeKey, "JsonSchema"),
 			.. IfHasProperty(mvcServerType, "MvcServer"),
 			.. IfHasProperty(clientType, "Client"),
+			.. IfHasProperty(configType, "Config"),
 		];
 
 		IEnumerable<string> IfHasProperty(string property, string result)

--- a/generators/csharp/OpenApiCodegen.CSharp/OpenApiCodegen.CSharp.props
+++ b/generators/csharp/OpenApiCodegen.CSharp/OpenApiCodegen.CSharp.props
@@ -10,10 +10,14 @@
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="DPDJsonSchema" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="DPDGenerateMvcServer" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="DPDGenerateClient" />
+		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="DPDSchemaOptions" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Configuration" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="Namespace" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="PathPrefix" />
 		<CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SchemaId" />
+
+		<OpenApiSchemaOptions Condition="Exists('$(ProjectDir)/csharp.config.yaml') and '' == '@(OpenApiSchemaOptions)'"
+			Include="$(ProjectDir)/csharp.config.yaml"/>
 
 		<AvailableItemName Include="OpenApiSchemaOptions" DisplayName="C# Options for Open API Code Generation (OpenApiCodeGen)" />
 		<AvailableItemName Include="OpenApiSchemaMvcServer" DisplayName="Open API Schema MVC Server (OpenApiCodeGen)" />
@@ -21,6 +25,7 @@
 		<Watch Include="@(OpenApiSchemaClient)" />
 		<Watch Include="@(OpenApiSchemaMvcServer)" />
 		<Watch Include="@(JsonSchemaDocument)" />
+		<Watch Include="@(OpenApiSchemaOptions)" />
 	</ItemGroup>
 
 	<Target Name="_InjectAdditionalFilesForOpenApiSchema" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
@@ -44,6 +49,8 @@
 				<Link Condition="'%(AdditionalFiles.Link)' == ''">@(OpenApiSchemaClient->'%(Link)')</Link>
 				<Namespace Condition="'%(AdditionalFiles.Namespace)' == ''">@(OpenApiSchemaClient->'%(Namespace)')</Namespace>
 				<SchemaId Condition="'%(AdditionalFiles.SchemaId)' == ''">@(OpenApiSchemaClient->'%(SchemaId)')</SchemaId>
+
+				<DPDSchemaOptions>@(OpenApiSchemaOptions->'true')</DPDSchemaOptions>
 			</AdditionalFiles>
 		</ItemGroup>
 		<ItemGroup>

--- a/generators/csharp/OpenApiCodegen.CSharp/README.md
+++ b/generators/csharp/OpenApiCodegen.CSharp/README.md
@@ -49,7 +49,9 @@ and to control the Namespace.
 
 ## Configuration
 
-Additional settings may be added within the `.csproj`. For example:
+Additional settings may be added within the `.csproj`. For example, see the below sections.
+
+### MVC Server
 
 ```xml
 <OpenApiSchemaMvcServer Include="schemas/petstore.yaml" Namespace="My.Extensions" Configuration="path/to/config.yaml" />
@@ -64,13 +66,22 @@ Additional settings may be added within the `.csproj`. For example:
   to external files. Otherwise, the absolute file-scheme URL will be used.
 
 In addition, adding the following to an ItemGroup in the csproj (or adding the
-yaml file with the build action `OpenApiSchemaCSharpServerOptions` via Visual
-Studio) will set the configuration yaml file for all client schemas that do not
-have one specifically set.
+yaml file with the build action `OpenApiSchemaOptions` via Visual
+Studio) will set the configuration yaml file for all schemas.
+
+### Client
 
 ```xml
-<OpenApiSchemaCSharpServerOptions Include="path/to/config.yaml" />
+<OpenApiSchemaClient Include="schemas/petstore.yaml" Namespace="My.Extensions" Configuration="path/to/config.yaml" />
 ```
+
+- `Namespace` - Overrides the namespace detected by the default namespace and
+  path of the schema file
+- `Configuration` - Additional configuration settings specific to this schema.
+  See the configuration yaml documentation below.
+- `SchemaId` - Specifies the "retrieval URI" used when resolving relative paths
+  to external files. Otherwise, the absolute file-scheme URL will be used.
+
 
 ### Configuration Yaml
 
@@ -123,7 +134,17 @@ overrideNames:
     format: float
     ```
 - `overrideNames` is a dictionary of schema URIs to the namespace-qualified C#
-  type name to use for the generated class. (Note: this feature is still experimental and may change or be removed in a later relaese.)
+  type name to use for the generated class. (Note: this feature is still
+  experimental and may change or be removed in a later relaese.)
+
+Configurations may be specified with the following setting:
+
+```xml
+<OpenApiSchemaOptions Include="path/to/config.yaml" />
+```
+
+Alternatively, if a `csharp.config.yaml` is placed in the root of your project
+without any other schema options being set, it will be included.
 
 ### Schema extensions
 


### PR DESCRIPTION
Adds an automatic `csharp.config.yaml` and causes configs to be loaded against all generators