### PR TITLE
Default package installation to use private assets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
 		<OpenApiAbstractionsVersion>0.2.0</OpenApiAbstractionsVersion>
 		<OpenApiJsonExtensionsVersion>0.17.1</OpenApiJsonExtensionsVersion>
 		<OpenApiLoadersVersion>0.1.0</OpenApiLoadersVersion>
-		<OpenApiCSharpVersion>0.21.0</OpenApiCSharpVersion>
+		<OpenApiCSharpVersion>0.21.1</OpenApiCSharpVersion>
 		<OpenApiTypeScriptClientVersion>0.11.1</OpenApiTypeScriptClientVersion>
 		<OpenApiTypeScriptRxjsClientVersion>0.8.1</OpenApiTypeScriptRxjsClientVersion>
 		<OpenApiTypeScriptMswVersion>0.8.1</OpenApiTypeScriptMswVersion>

--- a/generators/csharp/OpenApiCodegen.CSharp/OpenApiCodegen.CSharp.csproj
+++ b/generators/csharp/OpenApiCodegen.CSharp/OpenApiCodegen.CSharp.csproj
@@ -14,6 +14,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<IncludeBuildOutput>false</IncludeBuildOutput>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<DevelopmentDependency>true</DevelopmentDependency>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Setting `DevelopmentDependency` will default package installation to `PrivateAssets="all"`, which will exclude the package's analyzers from build outputs.