### PR TITLE
Use HttpMessageInvoker and pass CancellationToken

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
 		<OpenApiAbstractionsVersion>0.3.0</OpenApiAbstractionsVersion>
 		<OpenApiJsonExtensionsVersion>0.17.1</OpenApiJsonExtensionsVersion>
 		<OpenApiLoadersVersion>0.2.0</OpenApiLoadersVersion>
-		<OpenApiCSharpVersion>0.23.0</OpenApiCSharpVersion>
+		<OpenApiCSharpVersion>0.24.0</OpenApiCSharpVersion>
 		<OpenApiTypeScriptClientVersion>0.12.1</OpenApiTypeScriptClientVersion>
 		<OpenApiTypeScriptRxjsClientVersion>0.9.0</OpenApiTypeScriptRxjsClientVersion>
 		<OpenApiTypeScriptMswVersion>0.9.0</OpenApiTypeScriptMswVersion>

--- a/generators/csharp/OpenApiCodegen.CSharp.Base/Client/Templates/client.handlebars
+++ b/generators/csharp/OpenApiCodegen.CSharp.Base/Client/Templates/client.handlebars
@@ -18,11 +18,11 @@ namespace {{PackageName}}
         /// </remarks>{{/if}}{{#each RequestBody.AllParams}}
         /// <param name="{{ParamName}}">{{Description}}</param>{{/each}}
         public static async global::System.Threading.Tasks.Task<{{Operation.Name}}ReturnType> {{Operation.Name}}(
-            this global::System.Net.Http.HttpClient client,
+            this global::System.Net.Http.HttpMessageInvoker client,
             {{#each RequestBody.AllParams}}{{#unless Required}}global::DarkPatterns.OpenApiCodegen.Json.Extensions.Optional<{{/unless}}{{{DataType}}}{{#unless Required}}>?{{/unless}} {{ParamName}},
             {{/each}}
             global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken)
-        ) => await (await client.SendAsync({{Operation.Name}}({{#each RequestBody.AllParams}}{{ParamName}}{{#unless @last}},{{/unless}}{{/each}})).ConfigureAwait(false))
+        ) => await (await client.SendAsync({{Operation.Name}}({{#each RequestBody.AllParams}}{{ParamName}}{{#unless @last}},{{/unless}}{{/each}}), cancellationToken).ConfigureAwait(false))
             .Parse{{Operation.Name}}().ConfigureAwait(false);
 
         public static global::System.Net.Http.HttpRequestMessage {{Operation.Name}}(

--- a/generators/csharp/OpenApiCodegen.CSharp.Base/WebhookClient/Templates/webhooks.handlebars
+++ b/generators/csharp/OpenApiCodegen.CSharp.Base/WebhookClient/Templates/webhooks.handlebars
@@ -18,12 +18,12 @@ namespace {{PackageName}}
         /// </remarks>{{/if}}{{#each RequestBody.AllParams}}
         /// <param name="{{ParamName}}">{{Description}}</param>{{/each}}
         public static async global::System.Threading.Tasks.Task<{{Operation.Name}}ReturnType> {{Operation.Name}}(
-            this global::System.Net.Http.HttpClient client,
+            this global::System.Net.Http.HttpMessageInvoker client,
             global::System.Uri uri,
             {{#each RequestBody.AllParams}}{{#unless Required}}global::DarkPatterns.OpenApiCodegen.Json.Extensions.Optional<{{/unless}}{{{DataType}}}{{#unless Required}}>?{{/unless}} {{ParamName}},
             {{/each}}
             global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken)
-        ) => await (await client.SendAsync({{Operation.Name}}(uri{{#each RequestBody.AllParams}}, {{ParamName}}{{/each}})).ConfigureAwait(false))
+        ) => await (await client.SendAsync({{Operation.Name}}(uri{{#each RequestBody.AllParams}}, {{ParamName}}{{/each}}), cancellationToken).ConfigureAwait(false))
             .Parse{{Operation.Name}}().ConfigureAwait(false);
 
         public static global::System.Net.Http.HttpRequestMessage {{Operation.Name}}(


### PR DESCRIPTION
- `HttpMessageInvoker` is the base class of `HttpClient` and can be used instead for client generators.
- The `CancellationToken` was not being passed to `SendAsync` and now is.