### PR TITLE
Correct any schema

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -53,7 +53,7 @@ jobs:
       env:
         VERSION_SUFFIX: ${{ github.ref != 'refs/heads/main' && github.sha || '' }}
     - name: 'Upload Code Coverage'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage
         path: ./lib/*/TestResults/*/coverage.cobertura.xml

--- a/.github/workflows/dotnet-lint.yml
+++ b/.github/workflows/dotnet-lint.yml
@@ -1,7 +1,9 @@
 name: Lint DotNet
 on:
-  pull_request:
-    types: [edited, opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch: {}
+  # Disabled because the 8.x format is unreliable with source generators
+  # pull_request:
+  #   types: [edited, opened, reopened, synchronize, ready_for_review]
 
 jobs:
   build:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,8 +32,8 @@
 		<OpenApiAbstractionsVersion>0.3.0</OpenApiAbstractionsVersion>
 		<OpenApiJsonExtensionsVersion>0.18.0</OpenApiJsonExtensionsVersion>
 		<OpenApiLoadersVersion>0.2.0</OpenApiLoadersVersion>
-		<OpenApiCSharpVersion>0.25.0</OpenApiCSharpVersion>
-		<OpenApiTypeScriptClientVersion>0.12.1</OpenApiTypeScriptClientVersion>
+		<OpenApiCSharpVersion>0.25.1</OpenApiCSharpVersion>
+		<OpenApiTypeScriptClientVersion>0.12.2</OpenApiTypeScriptClientVersion>
 		<OpenApiTypeScriptRxjsClientVersion>0.9.0</OpenApiTypeScriptRxjsClientVersion>
 		<OpenApiTypeScriptMswVersion>0.9.0</OpenApiTypeScriptMswVersion>
 		<OpenApiTypeScriptFetchVersion>0.9.0</OpenApiTypeScriptFetchVersion>

--- a/eng/AutoCodeFormat.targets
+++ b/eng/AutoCodeFormat.targets
@@ -1,6 +1,6 @@
 <Project>
 	<ItemGroup>
-		<PackageReference Include="DarkPatterns.Build.Autoformat" Version="0.2.0" PrivateAssets="All" />
+		<!-- <PackageReference Include="DarkPatterns.Build.Autoformat" Version="0.2.0" PrivateAssets="All" /> -->
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/generators/typescript/npm/package.json
+++ b/generators/typescript/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@darkpatternsdigital/openapi-codegen-typescript",
-    "version": "0.10.0",
+    "version": "0.12.2",
     "description": "A typescript client code generator for principled development",
     "scripts": {
         "build": "tsc -b tsconfig.build.json",

--- a/lib/OpenApi.CSharp/CSharpInlineSchemas.cs
+++ b/lib/OpenApi.CSharp/CSharpInlineSchemas.cs
@@ -34,6 +34,10 @@ public class CSharpInlineSchemas(CSharpSchemaOptions options, DocumentRegistry d
 		var schemaInfo = CSharpTypeInfo.From(schema);
 		CSharpInlineDefinition result = schemaInfo switch
 		{
+			{ Info.EffectiveSchema.BoolValue: false } => new(options.Find(TypeAnnotation.Common.Object, "never")),
+			{ Info.EffectiveSchema.BoolValue: true } => new(options.Find(TypeAnnotation.Common.Object, "any")),
+			{ Info.Annotations.Count: 0 } => new(options.Find(TypeAnnotation.Common.Object, "any")),
+
 			// Dictionary
 			{ TypeAnnotation: { AllowsObject: true }, Properties: { Count: 0 }, AdditionalProperties: JsonSchema dictionaryValueSchema } =>
 				new(options.ToMapType(ToInlineDataType(dictionaryValueSchema).Text), IsEnumerable: true),

--- a/lib/OpenApi.TypeScript/TypeScriptInlineSchemas.cs
+++ b/lib/OpenApi.TypeScript/TypeScriptInlineSchemas.cs
@@ -103,10 +103,13 @@ public class TypeScriptInlineSchemas(TypeScriptSchemaOptions options, DocumentRe
 		var typeInfo = TypeScriptTypeInfo.From(schemaInfo);
 		TypeScriptInlineDefinition result = typeInfo switch
 		{
-			{ TypeAnnotation.AllowsArray: true, Items: null } => ArrayToInline(null),
-			{ Items: JsonSchema items } => ArrayToInline(items),
 			{ Info.EffectiveSchema.BoolValue: false } => new TypeScriptInlineDefinition("never", [], false, false),
 			{ Info.EffectiveSchema.BoolValue: true } => new TypeScriptInlineDefinition("unknown", [], true, false),
+			{ Info.Annotations.Count: 0 } =>
+				new TypeScriptInlineDefinition("unknown", [], true, false),
+
+			{ TypeAnnotation.AllowsArray: true, Items: null } => ArrayToInline(null),
+			{ Items: JsonSchema items } => ArrayToInline(items),
 			{ TypeAnnotation: v3_0.TypeKeyword { OpenApiType: var primitiveType }, Format: var format } =>
 				new(options.Find(TypeAnnotation.ToPrimitiveTypeString(primitiveType), format), []),
 			{ TypeAnnotation.AllowsNumber: true, Format: var format } =>

--- a/lib/TestApp/Annotations/Controllers.cs
+++ b/lib/TestApp/Annotations/Controllers.cs
@@ -1,6 +1,4 @@
-﻿using static DarkPatterns.OpenApiCodegen.Server.Mvc.TestApp.OneOf.PetControllerBase;
-
-namespace DarkPatterns.OpenApiCodegen.Server.Mvc.TestApp.Annotations
+﻿namespace DarkPatterns.OpenApiCodegen.Server.Mvc.TestApp.Annotations
 {
 	public class DogController : DogControllerBase
 	{

--- a/lib/TestApp/Any/Controllers.cs
+++ b/lib/TestApp/Any/Controllers.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Nodes;
+
+namespace DarkPatterns.OpenApiCodegen.Server.Mvc.TestApp.Any;
+
+public class DataController : DataControllerBase
+{
+	protected override Task<GetDataActionResult> GetData()
+	{
+		throw new NotImplementedException();
+	}
+
+	protected override Task<PutDataActionResult> PutData(JsonNode putDataBody)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/lib/TestApp/OpenApiCodegen.Server.Mvc.TestApp.csproj
+++ b/lib/TestApp/OpenApiCodegen.Server.Mvc.TestApp.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <OpenApiSchemaClient Include="$(SolutionRoot)schemas\all-of.yaml" Link="Clients\AllOf\all-of.yaml" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\all-of.yaml" Link="AllOf\all-of.yaml" PathPrefix="/all-of" />
+    <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\any.yaml" Link="Any\any.yaml" PathPrefix="/any" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\enum.yaml" Link="Enum\enum.yaml" PathPrefix="/enum" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\controller-extension.yaml" Link="ControllerExtensions\controller-extension.yaml" PathPrefix="/controller-extensions" />
     <OpenApiSchemaMvcServer Include="$(SolutionRoot)schemas\csharp-name-override.yaml" Link="CSharpNameOverride\csharp-name-override.yaml" PathPrefix="/csharp-name-override" />

--- a/schemas/any.yaml
+++ b/schemas/any.yaml
@@ -12,6 +12,15 @@ paths:
           description: Gets any kind of JSON data
           content:
             application/json:
-              schema:
-                type: object
-                format: any
+              schema: {}
+    put:
+      operationId: putData
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {}
+      responses:
+        '200':
+          description: Data received
+


### PR DESCRIPTION
Corrects handling of the two standard "any" schemas in both C# and TypeScript:
- `{}`
- `true`

This continues to support the non-standard `{ type: object, format: any }` that was supported previously.